### PR TITLE
[docs] Add troubleshooting steps to docs for GUI issue

### DIFF
--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -42,3 +42,19 @@ docker run -it mgoubran/miracl bash
 ```
 
 (this will be lost when you shell out)
+
+## Troubleshooting
+
+### Q: I get the following error whenever I try to run the GUI:
+
+Run the following to mount an X11 socket from the host system in the Docker container:
+
+    docker run --rm -ti -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix mgoubran/miracl bash
+
+If you still receive the above error, you may have to change your `xhost` access control:
+
+    xhost +
+
+This will disable access control for `xhost`. However, after exiting the container access control should be enabled again:
+
+    xhost -

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -45,16 +45,38 @@ docker run -it mgoubran/miracl bash
 
 ## Troubleshooting
 
-### Q: I get the following error whenever I try to run the GUI:
+### Q: I get either or both of the following errors whenever I try to run the GUI from within the Docker container:
 
-Run the following to mount an X11 socket from the host system in the Docker container:
+```
+Authorization required, but no authorization protocol specified
+qt.qpa.xcb: could not connect to display :1
+```
 
-    docker run --rm -ti -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix mgoubran/miracl bash
+(The number for the display could be different in your case)
 
-If you still receive the above error, you may have to change your `xhost` access control:
+```
+qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
+This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
 
-    xhost +
+Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, webgl, xcb.
+```
 
-This will disable access control for `xhost`. However, after exiting the container access control should be enabled again:
+Exit your running Docker container and run the following to mount an X11 socket from the host system in a new Docker container:
 
-    xhost -
+```
+docker run -it -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix mgoubran/miracl bash
+```
+
+If you still receive the above error, you may have to change your `xhost` access control on your host machine (**not** within your Docker container). Exit the running Docker container and type:
+
+```
+xhost +
+```
+
+This will disable access control for `xhost`. Start a new Docker container with the above command.
+
+Once you are done with working in the container, exit it and enable access control again on the host machine:
+
+```
+xhost -
+```

--- a/docs/install-singularity.md
+++ b/docs/install-singularity.md
@@ -35,6 +35,51 @@ Bind a data directory to it
 
     $ singularity shell -B data:/data miracl.sif
 
-
 #### For running functions on clusters please check our tutorials
 
+## Troubleshooting
+
+### Q: I get the following error whenever I try to run the GUI from within the Singularity container on Compute Canada:
+
+```
+qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
+This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
+
+Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, webgl, xcb.
+```
+
+**If you want to use X11 follow the below troubleshooting steps. However, using VNC instead of X11 should solve this issue and result in performance improvements. Instructions on how to use VNC on Compute Canada can be found [here](https://docs.alliancecan.ca/wiki/VNC).**
+
+### Login Nodes
+
+Exit your Singularity container and start a VNC server (for 3600sec or more as required) on your login node:
+
+```
+vncserver -MaxConnectionTime 3600
+```
+
+The first time the VNC server is started you will prompted for a password (do not leave this blank). Once done, check if a X11 socket is available for your username:
+
+```
+ls -la /tmp/.X11-unix/
+```
+
+(If no socket is available for your username, log out and log back in to your login node)
+
+Start another Singularity container and try to run `miraclGUI` again from within it.
+
+### Compute Nodes
+
+Exit your Singularity container and set an environment variable on your allocated compute node:
+
+```
+export XDG_RUNTIME_DIR=${SLURM_TMPDIR}
+```
+
+Start a VNC server:
+
+```
+vncserver
+```
+
+Start another Singularity container and try to run `miraclGUI` again from within it.


### PR DESCRIPTION
miraclGUI does not work when executed in a Docker container locally or in a Singularity container on a SLURM cluster. Several troubleshooting steps have been added to the install-singularity.md and install-docker.md docs as a workaround.