### PR TITLE
[fix] correct string formatting syntax error in cli_reg.py

### DIFF
--- a/miracl/reg/cli_reg.py
+++ b/miracl/reg/cli_reg.py
@@ -38,7 +38,7 @@ def run_mri_allen_ants(parser, args):
             subprocess.Popen('%s/reg/miracl_reg_mri-allen.sh -h' % miracl_home,
                              shell=True)
         else:
-            bash_args = '-i %s -o %s -m %s -v %s -l %s -b %s -s % -f %s' \
+            bash_args = '-i %s -o %s -m %s -v %s -l %s -b %s -s %s -f %s' \
                         % (args['in_nii'], args['ort'], args['hemi'], args['vox_res'], args['lbls'], args['bulb'],
                            args['skull'], args['bet'])
 
@@ -58,7 +58,7 @@ def run_mri_allen_nifty(parser, args):
             subprocess.Popen('%s/reg/miracl_reg_mri-allen_niftyreg.sh -h' % miracl_home,
                              shell=True)
         else:
-            bash_args = '-i %s -o %s -m %s -v %s -l %s -b %s -s % -f %s' \
+            bash_args = '-i %s -o %s -m %s -v %s -l %s -b %s -s %s -f %s' \
                         % (args['in_nii'], args['ort'], args['hemi'], args['vox_res'], args['lbls'], args['bulb'],
                            args['skull'], args['bet'])
 


### PR DESCRIPTION
Corrected string input formatting error for mri-allen-reg and mri-nifty-allen-reg in cli_reg.py which expect string input for certain flags. Currently a working pull request to establish that some changes need to be made for niftyreg and regular mri-allen-ants reg scripts to work. 