### PR TITLE
[fix] replace deprecated nibabel.trackvis.read

### DIFF
--- a/miracl/lbls/miracl_lbls_stats.py
+++ b/miracl/lbls/miracl_lbls_stats.py
@@ -244,7 +244,8 @@ def get_tract_count(tract_file):
     Args: tract_file - trk file
     """
     print('reading sta streamlines')
-    streams, hdr = nib.trackvis.read(tract_file)
+    streamlines_file = nib.streamlines.load(tract_file)
+    streams, hdr = streamlines_file.streamlines, streamlines_file.header
 
     return len(streams)
 

--- a/miracl/sta/miracl_sta_gen_tract_density.py
+++ b/miracl/sta/miracl_sta_gen_tract_density.py
@@ -80,7 +80,8 @@ def parse_inputs(parser, args):
 
 def gen_dens(tracts, ref_vol, out_dens):
     print('reading sta streamlines')
-    streams, hdr = nib.trackvis.read(tracts)
+    streamlines_file = nib.streamlines.load(tracts)
+    streams, hdr = streamlines_file.streamlines, streamlines_file.header
     streamlines = [s[0] for s in streams]
 
     print('reading reference volume')


### PR DESCRIPTION
Nibabel's method 'nibabel.trackvis.read' has been deprecated from version 2.5.0. It has been replaced with 'nibabel.streamlines.load' which returns an object that can't be assigned in parallel as it was done in the original code in which the object 'nibabel.trackvis.read' was returned. The deprecated method has been replaced and the syntax has been changed accordingly in 'miracl_sta_gen_tract_density.py' and 'miracl_lbls_stats.py'.