### PR TITLE
[fix] fix Seaborn positional arguments problem

### DIFF
--- a/miracl/stats/miracl_plot_single_subj.py
+++ b/miracl/stats/miracl_plot_single_subj.py
@@ -106,13 +106,13 @@ def generate_plot(input_csv, sort, threshold):
     
     # generate two plots, based on whether or not an acronym should be used
     sns.set(font_scale=1.2)
-    f = sns.barplot(sort,"acronym",data=in_df_sort_thresh, palette="Blues_r")
+    f = sns.barplot(x=sort,y="acronym",data=in_df_sort_thresh, palette="Blues_r")
     f.set(xlabel=f'{sort}', ylabel='Region acronym')
     plt.tight_layout()
     f.figure.savefig(f'{filename_no_ext}_barplot_acronyms.png', dpi=300)
 
     plt.figure(figsize=(20,20))
-    f = sns.barplot(sort,"name",data=in_df_sort_thresh, palette="Blues_r")
+    f = sns.barplot(x=sort,y="name",data=in_df_sort_thresh, palette="Blues_r")
     f.set(xlabel=f'{sort}', ylabel='Region')
     plt.yticks(rotation=30)
     plt.tight_layout()


### PR DESCRIPTION
From Seaborn version 0.12, the only valid positional argument will be 'data'. Passing other arguments without an explicit keyword will result in an error or misintertpretation. Fixed by explicitly passing x, y variables as keyword arguments to sns.barplot() call.