### PR TITLE
Add overwrite flag for ACE

### DIFF
--- a/miracl/flow/ace_test_interface_abstract.py
+++ b/miracl/flow/ace_test_interface_abstract.py
@@ -615,7 +615,8 @@ class CheckOverwriteFlag:
         )
 
         for folder in folder_locations:
-            shutil.rmtree(folder)
+            if folder.is_dir():
+                shutil.rmtree(folder)
     
     @staticmethod
     def _get_dirs(

--- a/miracl/flow/ace_test_interface_abstract.py
+++ b/miracl/flow/ace_test_interface_abstract.py
@@ -1,14 +1,16 @@
 import argparse
 import os
-import subprocess
 import shutil
+import subprocess
 import sys
-from pathlib import Path
-from miracl import miracl_logger
 from abc import ABC, abstractmethod
-from miracl.flow import miracl_workflow_ace_parser
+from pathlib import Path
+from typing import List
+
+from miracl import miracl_logger
+from miracl.flow import (miracl_workflow_ace_correlation,
+                         miracl_workflow_ace_parser, miracl_workflow_ace_stats)
 from miracl.seg import ace_interface
-from miracl.flow import miracl_workflow_ace_stats, miracl_workflow_ace_correlation
 
 logger = miracl_logger.logger
 
@@ -256,6 +258,13 @@ class ACEWorkflows:
 
         nifti_save_location = {}
 
+        CheckOverwriteFlag.validate_args(
+            args.overwrite,
+            per_subject_final_folder,
+            args.experiment,
+            args.control
+        )
+
         for type_ in ['control', 'experiment']:
 
             tiff_template = Path(args_dict[type_][1])
@@ -289,39 +298,41 @@ class ACEWorkflows:
                     args.sa_output_folder, "warp_final"
                 )
 
-                # TODO: make sure we're getting the right dir
                 args.single = base_dir / subject.stem / tiff_extension
 
-                self.segmentation.segment(args)
-                self.conversion.convert(args)
-                converted_nii_file = GetConverterdNifti.get_nifti_file(
-                    ace_flow_conv_output_folder
-                )
-                self.registration.register(
-                    args,
-                    dependent_folder=ace_flow_conv_output_folder,
-                    converted_nii_file=converted_nii_file,
-                )
-                # Stack tiff files for use in voxelization method
-                fiji_file = ace_flow_vox_output_folder / "stack_seg_tifs.ijm"
-                stacked_tif = ace_flow_vox_output_folder / "stacked_seg_tif.tif"
-                StackTiffs.check_folders(fiji_file, stacked_tif)
-                StackTiffs.stacking(fiji_file, stacked_tif, ace_flow_seg_output_folder)
-                self.voxelization.voxelize(args, stacked_tif)
-
+                if args.overwrite:
+                    self.segmentation.segment(args)
+                    self.conversion.convert(args)
+                    converted_nii_file = GetConverterdNifti.get_nifti_file(
+                        ace_flow_conv_output_folder
+                    )
+                    self.registration.register(
+                        args,
+                        dependent_folder=ace_flow_conv_output_folder,
+                        converted_nii_file=converted_nii_file,
+                    )
+                    # Stack tiff files for use in voxelization method
+                    fiji_file = ace_flow_vox_output_folder / "stack_seg_tifs.ijm"
+                    stacked_tif = ace_flow_vox_output_folder / "stacked_seg_tif.tif"
+                    StackTiffs.check_folders(fiji_file, stacked_tif)
+                    StackTiffs.stacking(fiji_file, stacked_tif, ace_flow_seg_output_folder)
+                    self.voxelization.voxelize(args, stacked_tif)
+                
+                # need to do this step regardless of overwrite or not
                 (
                     voxelized_segmented_tif,
                     orientation_file,
                 ) = GetVoxSegTif.check_warping_requirements(
                     ace_flow_vox_output_folder, ace_flow_warp_output_folder
                 )
-
-                GetVoxSegTif.create_orientation_file(
-                    orientation_file, ace_flow_warp_output_folder
-                )
-                self.warping.warp(
-                    args, ace_flow_reg_output_folder.parent / "clar_allen_reg", voxelized_segmented_tif, orientation_file
-                )
+                
+                if args.overwrite:
+                    GetVoxSegTif.create_orientation_file(
+                        orientation_file, ace_flow_warp_output_folder
+                    )
+                    self.warping.warp(
+                        args, ace_flow_reg_output_folder.parent / "clar_allen_reg", voxelized_segmented_tif, orientation_file
+                    )
             
             nifti_save_location[type_] = voxelized_segmented_tif # make sure this is the right file
         
@@ -466,7 +477,6 @@ class GetCorrInput:
             raise FileNotFoundError(f"'{file_path}' does not exist at '{dir_path}'")
 
 
-# TODO: may have to change for our new usage
 class ConstructHeatmapCmd:
     @staticmethod
     def test_none_args(
@@ -523,7 +533,6 @@ class ConstructHeatmapCmd:
     def construct_final_heatmap_cmd(
         args, ace_flow_heatmap_output_folder, tested_heatmap_cmd
     ):
-        # TODO: fix the params this function recieves
         tested_heatmap_cmd += f"\
             -g1 {args.pcs_control[0]} {args.pcs_control[1]} \
             -g2 {args.pcs_experiment[0]} {args.pcs_experiment[0]} \
@@ -538,6 +547,121 @@ class ConstructHeatmapCmd:
             --dpi {args.sh_dpi}"
 
         return tested_heatmap_cmd
+    
+class CheckOverwriteFlag:
+    @staticmethod
+    def validate_args(
+        overwrite: bool,
+        folder_name: str,
+        control: List[str],
+        experiment: List[str]
+    ):
+        """Validate the arguments for the save directories and the overwrite flag.
+
+        :param overwrite: Whether to overwrite existing results folders.
+        :type overwrite: bool
+        :param folder_name: Format of the results folder per subject.
+        :type folder_name: str
+        :param control: Base dir and tiff template for control subjects.
+        :type control: List[str]
+        :param experiment: Base dir and tiff template for experiment subjects.
+        :type experiment: List[str]
+        :raises ValueError: If not all subjects have existing results folders and overwrite is False.
+        """
+        # if we don't overwrite, check if the folder exists
+        if not overwrite:
+            folder_locations = CheckOverwriteFlag._get_dirs(
+                folder_name,
+                control,
+                experiment
+            )
+
+            # check that all the folders exist
+            if not all([folder.is_dir() for folder in folder_locations]):
+                raise ValueError(
+                    f"Not all subjects have existing results folder of the form \"{folder_name}\". "
+                    "Please specify --overwrite flag to create them."
+                )
+        
+        # clear the folders if we overwite
+        if overwrite:
+            CheckOverwriteFlag._clear_dirs(
+                folder_name,
+                control,
+                experiment
+            )
+            
+    @staticmethod
+    def _clear_dirs(
+        folder_name: str,
+        control: List[str],
+        experiment: List[str]
+    ):
+        """Clear the given directories for all subjects. This is used
+        when the overwrite flag is set to True.
+
+        :param folder_name: Directory name that must be removed for each subject.
+        :type folder_name: str
+        :param control: Base control dir and tiff template.
+        :type control: List[str]
+        :param experiment: Base experiment dir and tiff template.
+        :type experiment: List[str]
+        """
+        # clear the folders
+        folder_locations = CheckOverwriteFlag._get_dirs(
+            folder_name,
+            control,
+            experiment
+        )
+
+        for folder in folder_locations:
+            shutil.rmtree(folder)
+    
+    @staticmethod
+    def _get_dirs(
+        folder_name: str,
+        control: List[str],
+        experiment: List[str]
+    ) -> List[Path]:
+        """Get the folder locations for all subjects.
+        Uses the base directory and the tiff template to find the
+        folders.
+
+        :param folder_name: Per subject folder name to look for.
+        :type folder_name: str
+        :param control: Base control dir and tiff template.
+        :type control: List[str]
+        :param experiment: Base experiment dir and tiff template.
+        :type experiment: List[str]
+        :return: List of the folder locations for control and experiment subjects.
+        :rtype: List[Path]
+        """
+        folder_locations = []
+        # get the folder location for all subjects
+        control_tiff_template = Path(control[1])
+        control_base_dir = Path(control[0])
+
+        control_tiff_extension = Path(*control_tiff_template.relative_to(control_base_dir).parts[1:])
+        subject_folders = [dir_ for dir_ in control_base_dir.iterdir() if dir_.is_dir()]
+        save_folders = [
+            (subject / control_tiff_extension).parent / folder_name
+            for subject in subject_folders
+        ]
+        folder_locations.extend(save_folders)
+
+        experiment_tiff_template = Path(experiment[1])
+        experiment_base_dir = Path(experiment[0])
+
+        experiment_tiff_extension = Path(*experiment_tiff_template.relative_to(experiment_base_dir).parts[1:])
+        subject_folders = [dir_ for dir_ in experiment_base_dir.iterdir() if dir_.is_dir()]
+        save_folders = [
+            (subject / experiment_tiff_extension).parent / folder_name
+            for subject in subject_folders
+        ]
+        folder_locations.extend(save_folders)
+
+        return folder_locations
+        
 
 
 if __name__ == "__main__":

--- a/miracl/flow/miracl_workflow_ace_parser.py
+++ b/miracl/flow/miracl_workflow_ace_parser.py
@@ -87,7 +87,8 @@ class ACEWorkflowParser:
         )
         single_multi_args_group.add_argument(
             "--no-overwrite",
-            help="do not overwrite existing output files for comparison workflow",
+            help="do not overwrite existing output files for comparison workflow. "
+            "This flag can be used to run only the stats analysis (if the subject-only steps have already been run).",
             action="store_false",
             dest="overwrite",
         )

--- a/miracl/flow/miracl_workflow_ace_parser.py
+++ b/miracl/flow/miracl_workflow_ace_parser.py
@@ -80,6 +80,19 @@ class ACEWorkflowParser:
             nargs=2,
         )
 
+        single_multi_args_group.add_argument(
+            "--overwrite",
+            help="overwrite existing output files for comparison workflow",
+            action="store_true",
+        )
+        single_multi_args_group.add_argument(
+            "--no-overwrite",
+            help="do not overwrite existing output files for comparison workflow",
+            action="store_false",
+            dest="overwrite",
+        )
+        single_multi_args_group.set_defaults(overwrite=None)
+
         # Parser for input folder i.e. location of the data
         # required_args.add_argument(
         #     "-sai",
@@ -736,6 +749,10 @@ class ACEWorkflowParser:
         # check that something is passed
         elif not args.single and not args.control and not args.experiment:
             raise argparse.ArgumentError(None, 'either [-s/--single] or [-c/--control and -e/--experiment] must be passed')
+        
+        # check that the overwrite flag is supplied when in the multi workflow
+        if (args.control and args.experiment) and args.overwrite is None:
+            raise argparse.ArgumentError(None, '--overwrite or --no-overwrite flag must be supplied when running multi workflow')
         
         return args
 


### PR DESCRIPTION
Add overwrite flag for the comparison workflow of ACE. This forces the workflow to skip over the steps that are for single subjects (seg, conv, reg, vox, warp) and assumes (with checks) that these steps have already been performed. It then will perform only the comparison-based steps of the workflow (cluster, correlation, heatmap). 

This allows the user to skip the computation-intensive steps of the workflow once they have already been performed once. If one wants to just re-run the comparison-based steps, they can do so. 