### PR TITLE
[fix] fix clar allen warping fn

### DIFF
--- a/miracl/flow/miracl_workflow_ace_parser.py
+++ b/miracl/flow/miracl_workflow_ace_parser.py
@@ -473,7 +473,6 @@ class ACEWorkflowParser:
             "-rwcc",
             "--rwc_seg_channel",
             type=str,
-            default="green",
             help="Segmentation channel (ex. green) - required if voxelized seg is input",
         )
 


### PR DESCRIPTION
Parsing and in particular the channel argument were incorrectly implemented in the warping fn. The warping function can also be integrated into the ACE workflow now using "ace_flow" as the channel arg. "green" has been removed as the default string in the ACE interface parser.

Important: the warping fn should be integrated into the ACE workflow by passing "ace_flow" as an argument in the interface.

Note: warping script needs to more cleaning up (removing comments etc.) before next MIRACL release