### PR TITLE
Small fixes for ace docs

### DIFF
--- a/docs/installation/installation.rst
+++ b/docs/installation/installation.rst
@@ -109,6 +109,17 @@ either of the following methods:
 
          $ ./install.sh
 
+      .. attention::
+
+         If you want to add GPU support to your :program:`MIRACL` container,
+         you can do so by running the installation script with the ``-g`` flag:
+
+         .. code-block::
+
+            $ ./install.sh -g
+
+         This is needed if you want to run :doc:`ACE <../tutorials/workflows/ace_flow/ace_flow>`
+
       .. error::
          Make sure that the script can be executed. If it can't and you are 
          the owner of the file, use ``chmod u+x install.sh`` to make it 

--- a/docs/installation/installation.rst
+++ b/docs/installation/installation.rst
@@ -111,14 +111,15 @@ either of the following methods:
 
       .. attention::
 
-         If you want to add GPU support to your :program:`MIRACL` container,
-         you can do so by running the installation script with the ``-g`` flag:
+         If you want to add GPU (Nvidia/CUDA) support to your :program:`MIRACL`
+         container,         you can do so by running the installation script with the
+         ``-g`` flag:
 
          .. code-block::
 
             $ ./install.sh -g
 
-         This is needed if you want to run :doc:`ACE <../tutorials/workflows/ace_flow/ace_flow>`
+         This is needed if you want to run :doc:`ACE <../tutorials/workflows/ace_flow/ace_flow>`.
 
       .. error::
          Make sure that the script can be executed. If it can't and you are 

--- a/docs/tutorials/stats/ace_cluster/ace_cluster.rst
+++ b/docs/tutorials/stats/ace_cluster/ace_cluster.rst
@@ -38,9 +38,9 @@ Example usage (`link to sample data <https://drive.google.com/drive/folders/1IgN
 .. code-block::
 
    $ miracl stats ace \
-        -c ./ctrl/ \
-        -t ./treated/ \
-        -sao ./output_dir \
+        --control ./ctrl/ \
+        --treated ./treated/ \
+        --sa_output_folder ./output_dir \
         --sctp_num_perm 1000 \
         --rwc_voxel_size 25 \
         --sctp_smoothing_fwhm 3 \

--- a/docs/tutorials/stats/ace_cluster/ace_cluster.rst
+++ b/docs/tutorials/stats/ace_cluster/ace_cluster.rst
@@ -32,8 +32,19 @@ use the following command on the CLI:
 
 
 
-Example usage (`link to sample data <https://drive.google.com/drive/folders/1IgN9fDEVNeeT0a_BCzy3nReJWfxbrg72>`_):
-==================================================================================================================
+Example usage (`link to sample data <https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_stats.zip>`_):
+================================================================================================================================================
+
+.. note::
+
+   You must download the sample data and unzip it before running the following command.
+
+   .. code-block::
+
+      $ docker exec -it <CONTAINER_NAME> bash
+      $ wget https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_stats.zip
+      $ unzip ace_sample_data_stats.zip
+
 
 .. code-block::
 

--- a/docs/tutorials/workflows/ace_flow/ace_flow.rst
+++ b/docs/tutorials/workflows/ace_flow/ace_flow.rst
@@ -264,7 +264,14 @@ Example of running ACE on single subject (Mode 2) (`link to sample data <https:/
       --sa_resolution 3.5 3.5 4.0 \
       --ctn_down 10 \ 
       --rca_voxel_size 25 \
-      --ctn_channame Signal
+      --ctn_channame Signal \
+      --sa_batch_size 2
+
+.. tip::
+
+   Here we use a batch size of 2 for the DL model so that it fits in the GPU memory.
+   The batch size can be adjusted based on the GPU memory available on the current system.
+   Experienced users can try increasing the batch size to speed up the processing time.
 
 .. note::
 
@@ -279,7 +286,8 @@ Example of running only ACE segmentation module on one single subject (`link to 
    $ miracl seg ace \
       --single ./Ex_561_Em_600_stitched/ \
       --sa_output_folder ./output_dir \
-      --sa_model_type unetr
+      --sa_model_type unetr \
+      --sa_batch_size 2
 
 
 Example of running only ACE cluster wise analysis on voxelized and warped segmentation maps (`link to sample data <https://drive.google.com/drive/folders/1IgN9fDEVNeeT0a_BCzy3nReJWfxbrg72>`__):

--- a/docs/tutorials/workflows/ace_flow/ace_flow.rst
+++ b/docs/tutorials/workflows/ace_flow/ace_flow.rst
@@ -65,6 +65,11 @@ These models will be included by default in a future release once ACE is publish
       best_metric_model.pth
       best_metric_model.pth
 
+.. note::
+   By default, the installation script mounts the ``<WHERE YOU CLONED MIRACL>/miracl/`` directory to the docker container
+   at ``/code/miracl/``. Thus, copying the model files to right location **outside** the docker container will make them
+   available inside the container.
+
 
 Main Inputs
 ============

--- a/docs/tutorials/workflows/ace_flow/ace_flow.rst
+++ b/docs/tutorials/workflows/ace_flow/ace_flow.rst
@@ -82,6 +82,11 @@ OR
 Mode 2: Running ACE for a single subject
 - A single directory containing a single subject's whole-brain 3D LSFM dataset.
 
+.. note::
+
+   The trained DL models are not considered inputs, but are required to
+   run ACE. 
+
 Command Line Interface (CLI)
 ============================
 
@@ -251,8 +256,18 @@ Example of running ACE flow on multiple subjects (Mode 1):
       --sa_model_type unet
 
 
-Example of running ACE on single subject (Mode 2) (`link to sample data <https://drive.google.com/drive/folders/14xWysQshKxwuTDWEQHT3OGKcH16scrrQ>`__):
-=======================================================================================================================================================
+Example of running ACE on single subject (Mode 2) (`link to sample data <https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_mode_2.zip>`__):
+======================================================================================================================================================================================
+
+.. note::
+   
+   You must download the sample data and unzip it before running the following command.
+
+   .. code-block::
+
+      $ docker exec -it <CONTAINER_NAME> bash
+      $ wget https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_mode_2.zip
+      $ unzip ace_sample_data_mode_2.zip
 
 .. code-block::
 
@@ -278,8 +293,18 @@ Example of running ACE on single subject (Mode 2) (`link to sample data <https:/
    The user can also run the ACE segmentation module or the ACE cluster-wise analysis module separately.
    Examples of running these modules separately are provided below.
 
-Example of running only ACE segmentation module on one single subject (`link to sample data <https://drive.google.com/drive/folders/14xWysQshKxwuTDWEQHT3OGKcH16scrrQ>`__):
-=======================================================================================================================================================================================
+Example of running only ACE segmentation module on one single subject (`link to sample data <https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_mode_2.zip>`__):
+==========================================================================================================================================================================================================
+
+.. note::
+   
+   You must download the sample data and unzip it before running the following command.
+
+   .. code-block::
+
+      $ docker exec -it <CONTAINER_NAME> bash
+      $ wget https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_mode_2.zip
+      $ unzip ace_sample_data_mode_2.zip
 
 .. code-block::
 
@@ -290,8 +315,18 @@ Example of running only ACE segmentation module on one single subject (`link to 
       --sa_batch_size 2
 
 
-Example of running only ACE cluster wise analysis on voxelized and warped segmentation maps (`link to sample data <https://drive.google.com/drive/folders/1IgN9fDEVNeeT0a_BCzy3nReJWfxbrg72>`__):
-=============================================================================================================================================================================================================
+Example of running only ACE cluster wise analysis on voxelized and warped segmentation maps (`link to sample data <https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_stats.zip>`__):
+===============================================================================================================================================================================================================================
+
+.. note::
+
+   You must download the sample data and unzip it before running the following command.
+
+   .. code-block::
+
+      $ docker exec -it <CONTAINER_NAME> bash
+      $ wget https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_stats.zip
+      $ unzip ace_sample_data_stats.zip
 
 .. code-block::
 

--- a/docs/tutorials/workflows/ace_flow/ace_flow.rst
+++ b/docs/tutorials/workflows/ace_flow/ace_flow.rst
@@ -66,8 +66,9 @@ These models will be included by default in a future release once ACE is publish
       best_metric_model.pth
 
 .. note::
-   By default, the installation script mounts the ``<WHERE YOU CLONED MIRACL>/miracl/`` directory to the docker container
-   at ``/code/miracl/``. Thus, copying the model files to right location **outside** the docker container will make them
+   By default, the installation script mounts the ``<WHERE YOU CLONED MIRACL>/miracl/``
+   directory to the docker container at ``/code/miracl/``. Thus, copying the model
+   files to the right location **outside** the docker container will make them
    available inside the container.
 
 

--- a/docs/tutorials/workflows/ace_flow/ace_flow.rst
+++ b/docs/tutorials/workflows/ace_flow/ace_flow.rst
@@ -252,9 +252,14 @@ Example of running ACE on single subject (Mode 2) (`link to sample data <https:/
 .. code-block::
 
    $ miracl flow ace \
-      -s ./non_walking/Newton_HC1/cells/ \
+      -s ./Ex_561_Em_600_stitched/ \
       -sao ./output_dir \
-      -sam unet
+      -sam unet \
+      -rcao ARI \
+      -sar 3.5 3.5 4.0 \
+      -ctnd 10 \ 
+      -rcav 25 \
+      --ctn_channame Signal
 
 .. note::
 
@@ -269,12 +274,7 @@ Example of running only ACE segmentation module on one single subject (`link to 
    $ miracl seg ace \
       -sai ./Ex_561_Em_600_stitched/ \
       -sao ./output_dir \
-      -sam unetr \
-      -rcao ARI \
-      -sar 3.5 3.5 4.0 \
-      -ctnd 10 \ 
-      -rcav 25 \
-      --ctn_channame Signal
+      -sam unetr
 
 
 Example of running only ACE cluster wise analysis on voxelized and warped segmentation maps (`link to sample data <https://drive.google.com/drive/folders/1IgN9fDEVNeeT0a_BCzy3nReJWfxbrg72>`__):

--- a/docs/tutorials/workflows/ace_flow/ace_flow.rst
+++ b/docs/tutorials/workflows/ace_flow/ace_flow.rst
@@ -245,10 +245,10 @@ Example of running ACE flow on multiple subjects (Mode 1):
 .. code-block::
 
    $ miracl flow ace \
-      -c ./non_walking/ ./non_walking/Newton_HC1/cells/ \
-      -t ./walking/ ./walking/Newton_UI1/cells/ \
-      -sao ./output_dir \
-      -sam unet
+      --control ./non_walking/ ./non_walking/Newton_HC1/cells/ \
+      --treated ./walking/ ./walking/Newton_UI1/cells/ \
+      --sa_output_folder ./output_dir \
+      --sa_model_type unet
 
 
 Example of running ACE on single subject (Mode 2) (`link to sample data <https://drive.google.com/drive/folders/14xWysQshKxwuTDWEQHT3OGKcH16scrrQ>`__):
@@ -257,13 +257,13 @@ Example of running ACE on single subject (Mode 2) (`link to sample data <https:/
 .. code-block::
 
    $ miracl flow ace \
-      -s ./Ex_561_Em_600_stitched/ \
-      -sao ./output_dir \
-      -sam unet \
-      -rcao ARI \
-      -sar 3.5 3.5 4.0 \
-      -ctnd 10 \ 
-      -rcav 25 \
+      --single ./Ex_561_Em_600_stitched/ \
+      --sa_output_folder ./output_dir \
+      --sa_model_type unet \
+      --rca_orient_code ARI \
+      --sa_resolution 3.5 3.5 4.0 \
+      --ctn_down 10 \ 
+      --rca_voxel_size 25 \
       --ctn_channame Signal
 
 .. note::
@@ -277,9 +277,9 @@ Example of running only ACE segmentation module on one single subject (`link to 
 .. code-block::
 
    $ miracl seg ace \
-      -sai ./Ex_561_Em_600_stitched/ \
-      -sao ./output_dir \
-      -sam unetr
+      --single ./Ex_561_Em_600_stitched/ \
+      --sa_output_folder ./output_dir \
+      --sa_model_type unetr
 
 
 Example of running only ACE cluster wise analysis on voxelized and warped segmentation maps (`link to sample data <https://drive.google.com/drive/folders/1IgN9fDEVNeeT0a_BCzy3nReJWfxbrg72>`__):
@@ -288,10 +288,10 @@ Example of running only ACE cluster wise analysis on voxelized and warped segmen
 .. code-block::
 
    $ miracl stats ace \
-      -c ./ctrl/ \
-      -t ./treated/ \
-      -sao ./output_dir \
-      -rwcv 25
+      --control ./ctrl/ \
+      --treated ./treated/ \
+      --sa_output_folder ./output_dir \
+      --rwc_voxel_size 25
 
 More information on the ``miracl stats ace`` function can be found
 :doc:`here <../../stats/ace_cluster/ace_cluster>`.

--- a/install.sh
+++ b/install.sh
@@ -314,9 +314,9 @@ if [ -x "$(command -v docker)" ]; then
         # Test if docker-compose is installed
         # Should come by default with Docker-Desktop
         if [ -x "$(command -v docker-compose)" ]; then
-          printf "Docker Compose installation found (%s). Run 'docker-compose up -d' to start the MIRACL container in background.\n" "$(docker-compose --version)"
+          printf "Docker Compose installation found (%s). Run 'docker-compose up -d' to start the ${container_name} container in background.\n" "Run 'docker exec -it ${container_name} bash' to enter the container.\n" "$(docker-compose --version)"
         elif dcex=$(docker compose version); then
-          printf "Docker Compose installation found (%s). Run 'docker compose up -d' or use Docker Desktop (if installed) to start the MIRACL container in background.\n" "$dcex"
+          printf "Docker Compose installation found (%s). Run 'docker compose up -d' or use Docker Desktop (if installed) to start the ${container_name} container in background.\n" "Run 'docker exec -it ${container_name} bash' to enter the container.\n" "$dcex"
         else
           printf "Docker Compose installation not found. Please install Docker Compose plugin or standalone version to run the MIRACL container. Instructions on how to install Docker Compose can be found here: https://docs.docker.com/compose/install/\n"
         fi


### PR DESCRIPTION
Items completed
- Swap ACE single subject and ACE stats commands that were in the wrong spots
- Add explanation that docker is mounting `miracl/` by default
- Change the example code to contain only full-length flags
- Change the batch size for ACE example code
- Add explicit GPU flag on the installation page
- Change sample data download to HuggingFace