### PR TITLE
[fix] Add shm back to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,7 @@ function usage()
    -t, set when using specific MIRACL tag/version. Use 'auto' to parse from 'miracl/version.txt' or specify version as floating point value in format 'x.x.x' (default: 'latest')
    -g, enable Nvidia GPU passthrough mode for Docker container which is required for some of MIRACL's scripts e.g. ACE segmentation (default: false)
    -e, disable mounting MIRACL's script directory into Docker container. Mounting is useful if you want host changes to propagate to the container directly (default: enabled)
-   -d, manually set limit on max amount of memory the container can use ('--memory'). E.g. '1024mb', '16gb' or '512gb'. This is good practice for memory intensive applications like ACE (default: int(MemTotal/1024)*0.85 of host machine)
+   -d, set shared memory (shm) size (e.g. '1024mb', '16gb' or '512gb') which is important for e.g ACE (default: int(MemTotal/1024)*0.85 of host machine)
    -v, mount volumes for MIRACL in docker-compose.yml, using a separate flag for each additional volume (format: '/path/on/host:/path/in/container'; default: none)
    -l, write logfile of build process to 'build.log' in MIRACL root directory (default: false)
    -s, print version of build script and exit

--- a/install.sh
+++ b/install.sh
@@ -39,9 +39,9 @@ miracl_version_file=$(cat ./miracl/version.txt)
 
 # Set container memory size limit
 if [[ "$os" == "Linux" ]]; then
-    mem=$(grep MemTotal /proc/meminfo | awk '{printf "%dmb", int($2/1024*0.85)}')
+    shm_mem=$(grep MemTotal /proc/meminfo | awk '{printf "%dmb", int($2/1024*0.85)}')
 elif [[ "$os" == "Darwin" ]]; then
-    mem=$(sysctl hw.memsize | awk '{printf "%dmb", int($2/1024/1024*0.85)}')
+    shm_mem=$(sysctl hw.memsize | awk '{printf "%dmb", int($2/1024/1024*0.85)}')
 else
     echo "Unsupported operating system: $os"
     exit 1
@@ -131,8 +131,8 @@ while getopts ":n:i:c:t:ged:v:lsmh" opt; do
       ;;
 
     d)
-      if [ "${OPTARG}" != "$mem" ]; then
-      mem=${OPTARG}
+      if [ "${OPTARG}" != "$shm_mem" ]; then
+      shm_mem=${OPTARG}
       fi
       ;;
 
@@ -191,7 +191,7 @@ services:
     stdin_open: true
     network_mode: host
     container_name: $container_name
-    mem_limit: $mem
+    shm_size: ${shm_mem}
 EOF
 
 if [[ $gpu ]]; then
@@ -285,7 +285,7 @@ if [ -x "$(command -v docker)" ]; then
       printf " User: %s\n" "$HOST_USER"
       printf " pid: %s\n" "$(id -u)"
       printf " gid: %s\n" "$(id -g)"
-      printf " Max memory: %s\n" "$mem"
+      printf " Max shared memory: %s\n" "$shm_mem"
       printf " Service name: %s\n" "$service_name"
       printf " Image name: %s\n" "$image_name:$miracl_version"
       printf " Container name: %s\n" "$container_name"


### PR DESCRIPTION
The `docker-compose.yml` needs shm option since the ACE dataloaders rely on shared memory.