### PR TITLE
[docs] Fix stale ACE links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We have released our AI-based Cartography of Ensembles (ACE) workflow, an end-to
 segmentation models and advanced statistical methods to enable unbiased and generalizable brain-wide mapping of 3D alterations in neuronal activity, 
 morphology, or connectivity at the sub-regional and laminar levels beyond atlas-defined regions.
 
-ACE is now available [here](https://github.com/AICONSlab/MIRACL/tree/ace). Tutorials and usage examples for ACE can be found in our [docs](https://miracl.readthedocs.io/en/latest/tutorials/workflows/ace_flow/ace_flow.html).
+ACE is now available. Tutorials and usage examples for ACE can be found in our [docs](https://miracl.readthedocs.io/en/latest/tutorials/workflows/ace_flow/ace_flow.html).
 
 ___
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ Welcome to MIRACL's documentation!
 \*\*NEW WORKFLOW/FEATURE RELEASE\*\*
 """""""""""""""""""""""""""""""""""""""""
 
-We have released our `AI-based Cartography of Ensembles (ACE) <https://github.com/AICONSlab/MIRACL/tree/ace>`_ workflow, an end-to-end, automated pipeline that integrates cutting-edge deep learning segmentation models and advanced statistical methods to enable unbiased and generalizable brain-wide mapping of 3D alterations in neuronal activity, morphology, or connectivity at the sub-regional and laminar levels beyond atlas-defined regions.
+We have released our `AI-based Cartography of Ensembles (ACE) <https://github.com/AICONSlab/MIRACL>`_ workflow, an end-to-end, automated pipeline that integrates cutting-edge deep learning segmentation models and advanced statistical methods to enable unbiased and generalizable brain-wide mapping of 3D alterations in neuronal activity, morphology, or connectivity at the sub-regional and laminar levels beyond atlas-defined regions.
 
 The tutorial for using ACE can be found `here <https://miracl.readthedocs.io/en/latest/tutorials/workflows/ace_flow/ace_flow.html>`_.
 

--- a/docs/tutorials/workflows/ace_flow/ace_flow.rst
+++ b/docs/tutorials/workflows/ace_flow/ace_flow.rst
@@ -4,12 +4,12 @@ ACE Workflow
 **A**\ I-based **C**\ artography of **E**\ nsembles (**ACE**) pipeline highlights:
 
 1. Cutting-edge vision transformer and CNN-based DL architectures trained on 
-   very large LSFM datasets (`link to sample data <https://drive.google.com/drive/folders/14xWysQshKxwuTDWEQHT3OGKcH16scrrQ>`__
+   very large LSFM datasets (`link to sample data <https://huggingface.co/datasets/AICONSlab/MIRACL/blob/dev/sample_data/ace/ace_sample_data_mode_2.zip>`__
    and :ref:`refer to example section<example_anchor>`) to map brain-wide local/laminar neuronal activity.
 2. Optimized cluster-wise statistical analysis with a threshold-free 
    enhancement approach to chart subpopulation-specific effects at the laminar 
    and local level, without restricting the analysis to atlas-defined regions 
-   (`link to sample data <https://drive.google.com/drive/folders/1IgN9fDEVNeeT0a_BCzy3nReJWfxbrg72>`__ 
+   (`link to sample data <https://huggingface.co/datasets/AICONSlab/MIRACL/blob/dev/sample_data/ace/ace_sample_data_stats.zip>`__ 
    and :ref:`refer to example section<example_anchor>`).
 3. Modules for providing DL model uncertainty estimates and fine-tuning (in a future release).
 4. Interface with MIRACL registration.


### PR DESCRIPTION
- Update old ACE links pointing to `ace` branch
- Links points to main GitHub page now