### PR TITLE
[fix] pin typer to 0.11.1 to fix MIRACL breaking changes introduced by ACE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(
         "torch==1.13.1",
         "torchaudio==0.13.1",
         "torchvision==0.14.1",
+        "torchio==0.18.92",
+        "typer==0.11.1",
         "opencv-python==4.2.0.32",
         "tifffile==2021.11.2",
         "nibabel==4.0.2",
@@ -65,9 +67,8 @@ setup(
         "scikit-learn==1.0.2",
         "svgwrite==1.4.3",
         "loguru==0.6.0",
-        'mne==1.3.1',
-        'imagecodecs==2021.11.20',
-        'torchio==0.18.92'
+        "mne==1.3.1",
+        "imagecodecs==2021.11.20",
     ],
     entry_points={
         "console_scripts": ["miracl=miracl.cli:main"],


### PR DESCRIPTION
Python's typer package is automatically being installed as part of PyTorch. However, the Typer version installed was > 0.12.0 which changed its dependency structure, removing the need for typer[all]. After version 0.12.0, the typer package uses typer-slim[standard] which includes the default dependencies, instead of typer[all]. This introduced breaking changes to MIRACL and the installed version of PyTorch. Pinning the version to 0.11.1 solved the issue. Also moved up torchio to more clearly cluster it with other PyTorch packages.