### PR TITLE
[feat] disable Singularity build/upload in CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,45 +41,45 @@ jobs:
             docker run -it mgoubran/miracl echo "Docker run test"
       - store_test_results:
           path: /tmp/tests
-  singularity-publish:
-    docker:
-      - image: quay.io/singularity/singularity:v3.10.3
-    working_directory: /root/project/MIRACL
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Compile and push Singularity image
-          no_output_timeout: 2h
-          command: |
-            # Log in to cloud.sylabs.io
-            echo $SYLABS_TOKEN_JAN_21_2025 > tokenfile && \
-            singularity remote login -u aiconslab --tokenfile tokenfile && \
-            # Create Singularity container remotely and push to cloud
-            singularity build miracl.sif docker://mgoubran/miracl:latest
-            # Setting trap in case image cannot be deleted
-            set -e
-            trap "echo 'Image doesn't exist - catching error!'; if [ $? == 255 ]; then echo 'Error 255'; fi" ERR
-            # Remove current Singularity container
-            singularity delete --force library://aiconslab/miracl/miracl:latest && \
-            # Unset trap
-            trap - ERR
-            singularity push -U miracl.sif library://aiconslab/miracl/miracl:latest
-  singularity-build:
-    docker:
-      - image: quay.io/singularity/singularity:v3.10.3
-    working_directory: /root/project/MIRACL
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Compile and push Singularity image
-          no_output_timeout: 2h
-          command: |
-            # Create Singularity container remotely and push to cloud
-            singularity build miracl.sif docker://mgoubran/miracl:dev-latest
+  # singularity-publish:
+  #   docker:
+  #     - image: quay.io/singularity/singularity:v3.10.3
+  #   working_directory: /root/project/MIRACL
+  #   steps:
+  #     - checkout
+  #     - setup_remote_docker:
+  #         docker_layer_caching: true
+  #     - run:
+  #         name: Compile and push Singularity image
+  #         no_output_timeout: 2h
+  #         command: |
+  #           # Log in to cloud.sylabs.io
+  #           echo $SYLABS_TOKEN_JAN_21_2025 > tokenfile && \
+  #           singularity remote login -u aiconslab --tokenfile tokenfile && \
+  #           # Create Singularity container remotely and push to cloud
+  #           singularity build miracl.sif docker://mgoubran/miracl:latest
+  #           # Setting trap in case image cannot be deleted
+  #           set -e
+  #           trap "echo 'Image doesn't exist - catching error!'; if [ $? == 255 ]; then echo 'Error 255'; fi" ERR
+  #           # Remove current Singularity container
+  #           singularity delete --force library://aiconslab/miracl/miracl:latest && \
+  #           # Unset trap
+  #           trap - ERR
+  #           singularity push -U miracl.sif library://aiconslab/miracl/miracl:latest
+  # singularity-build:
+  #   docker:
+  #     - image: quay.io/singularity/singularity:v3.10.3
+  #   working_directory: /root/project/MIRACL
+  #   steps:
+  #     - checkout
+  #     - setup_remote_docker:
+  #         docker_layer_caching: true
+  #     - run:
+  #         name: Compile and push Singularity image
+  #         no_output_timeout: 2h
+  #         command: |
+  #           # Create Singularity container remotely and push to cloud
+  #           singularity build miracl.sif docker://mgoubran/miracl:dev-latest
 
 workflows:
   build_and_test:
@@ -127,14 +127,14 @@ workflows:
                    DOCKER_TAG=$(docker run --entrypoint /bin/cat mgoubran/miracl:latest /code/miracl/version.txt)
                    echo "Version for Docker tag is ${DOCKER_TAG}"
                    docker tag mgoubran/miracl:latest mgoubran/miracl:${DOCKER_TAG}
-      - singularity-publish:
-          context:
-            - miracl_singularity
-          requires:
-            - docker-publish/publish
-          filters:
-            branches:
-              only: master
+      # - singularity-publish:
+      #     context:
+      #       - miracl_singularity
+      #     requires:
+      #       - docker-publish/publish
+      #     filters:
+      #       branches:
+      #         only: master
   
   docker_with_lifecycle_dev:
     jobs:
@@ -151,11 +151,11 @@ workflows:
                    DOCKER_TAG=$(docker run --entrypoint /bin/cat mgoubran/miracl:dev-latest /code/miracl/version.txt)
                    echo "Version for Docker tag is ${DOCKER_TAG}"
                    docker tag mgoubran/miracl:dev-latest mgoubran/miracl:dev-${DOCKER_TAG}
-      - singularity-build:
-          context:
-            - miracl_singularity
-          requires:
-            - docker-publish/publish
-          filters:
-            branches:
-              only: dev
+      # - singularity-build:
+      #     context:
+      #       - miracl_singularity
+      #     requires:
+      #       - docker-publish/publish
+      #     filters:
+      #       branches:
+      #         only: dev

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ACE is now available. Tutorials and usage examples for ACE can be found in our [
 
 ___
 
-We recommend using MIRACL with the Docker or Singularity containers we provide. Legacy instructions for installing MIRACL locally are available but we recommend against it. For more details, see our 
+We recommend using MIRACL with the Docker or Apptainer containers we provide. Legacy instructions for installing MIRACL locally are available but we recommend against it. For more details, see our 
 [docs](https://miracl.readthedocs.io).
 
 ___

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ The tutorial for using ACE can be found `here <https://miracl.readthedocs.io/en/
 
 ------
 
-We recommend using MIRACL with the Docker or Singularity containers we provide 
+We recommend using MIRACL with the Docker or Apptainer containers we provide 
 but it can also be installed locally. See our 
 :doc:`installation instructions <./installation/installation>` for more information.
 

--- a/docs/installation/installation.rst
+++ b/docs/installation/installation.rst
@@ -6,38 +6,33 @@ either of the following methods:
 
 .. important::
    :program:`Docker` is our recommended method for running :program:`MIRACL` 
-   on local machines and servers. We recommend :program:`Singularity` to run 
+   on local machines and servers. We recommend :program:`Apptainer` to run 
    :program:`MIRACL` in a cluster environment (e.g. Compute Canada).
 
 .. attention::
    Support for installing :program:`MIRACL` locally (i.e. on your host 
-   system directly without using :program:`Docker` or :program:`Singularity`) 
-   has been deprecated. Please use :program:`Docker` or :program:`Singularity`
+   system directly without using :program:`Docker` or :program:`Apptainer`) 
+   has been deprecated. Please use :program:`Docker` or :program:`Apptainer`
    instead.
 
 .. important::
    :program:`MIRACL` has been tested on:
 
-   * **Docker**:
+   * **Docker (version 27.3.1, build ce12230)**:
 
      * **Ubuntu**: ``20.04`` (Focal Fossa), ``22.04`` (Jammy Jellyfish), ``24.04`` (Noble Numbat)
 
      * **Debian**: ``13`` (trixie)
 
-   * **Singularity**:
+   * **Apptainer (version 1.3.5)**:
 
      * **Ubuntu**: ``20.04`` (Focal Fossa), ``22.04`` (Jammy Jellyfish), ``24.04`` (Noble Numbat)
 
      * **Gentoo**: ``2.14``
 
-   * **Apptainer**:
-
-     * **Ubuntu**: ``20.04`` (Focal Fossa)
-
-     * **Gentoo**: ``2.14``
-
-   We strongly recommend that you use one of the above Linux versions to run
-   :program:`MIRACL`!
+   We strongly recommend that you use one of the above Linux versions but 
+   :program:`MIRACL` will most likely work on other versions of Linux as long
+   as :program:`Docker` or :program:`Apptainer` are installed and working.
 
 .. note::
    Hardware requirements for :program:`MIRACL` are heavily dependent on the 
@@ -63,7 +58,7 @@ either of the following methods:
 
       Docker is well suited if you want to run :program:`MIRACL` on a local 
       machine or local server. If you need to run :program:`MIRACL` on a 
-      cluster, see our instructions for installing :program:`Apptainer/Singularity`. 
+      cluster, see our instructions for installing :program:`Apptainer`. 
       If you don't have Docker installed on your computer, do that first. Make 
       sure your installation includes :program:`Docker Compose` as it is 
       required to run the installation script we provide. Note that :program:`Docker 
@@ -439,22 +434,22 @@ either of the following methods:
          Our script will automatically detect the version of the branch you 
          checked out and tag the image accordingly.
 
-   .. tab:: Singularity
+   .. tab:: Apptainer
 
-      Unlike :program:`Docker`, :program:`Singularity` is well suited to run in 
+      Unlike :program:`Docker`, :program:`Apptainer` is well suited to run in 
       a cluster environment (like Sherlock at Stanford or Compute Canada). We 
       provide the latest version of :program:`MIRACL` as a 
-      :program:`Singularity` container that can be conveniently pulled from 
-      cloud storage.
+      :program:`Apptainer` container that can be conveniently build from our 
+      :program:`Docker` image on Dockerhub or downloaded from HuggingFace.
 
       .. tip::
-         This is our recommended method for running :program:`MIRACL` in a 
-         SLURM cluster environment such as Compute Canada or Sherlock @ 
-         Stanford
+         :program:`Apptainer` is our recommended method for running 
+         :program:`MIRACL` in a SLURM cluster environment such as Compute 
+         Canada or Sherlock @ Stanford
 
       .. raw:: html
 
-         <h2>Download container</h2>
+         <h2>Build from Docker</h2>
 
       First, log in to the cluster:
       
@@ -465,22 +460,53 @@ either of the following methods:
       ``<cluster>`` could be ``sherlock.stanford.edu`` or 
       ``cedar.computecanada.ca`` for example
       
-      Once logged in, change the directory to your scratch space and pull 
-      (download) the :program:`Singularity` container:
-      
+      Once logged in, make sure that the :program:`Apptainer` binary is 
+      available. On SLURM cluster you might have to load it as a module. Once
+      you confirmed, that :program:`Apptainer` is installed and working,
+      navigate to the folder you want to create the :program:`Apptainer`
+      container in. On a SLURM cluster that could be your scratch folder:
+
       .. code-block::
 
          $ cd $SCRATCH
-         $ singularity pull miracl_latest.sif library://aiconslab/miracl/miracl:latest
+
+      Once there use the following command to create the container off of the 
+      :program:`MIRACL` image hosted on DockerHub:
+
+      .. code-block::
+
+         $ apptainer build miracl.sif docker://mgoubran/miracl:latest
+
+      The building process should start and the container will be available 
+      once the process has finished.
+
+      .. raw:: html
+
+         <h2>Download container</h2>
+
+      If, for some reason, the :program:`Apptainer` image cannot be built using
+      our DockerHub image, you can directly download a pre-compiled image of
+      :program:`MIRACL` that we host on HuggingFace.
+
+      To do so, log in to your cluster as described above and navigate to the
+      folder you want to save the :program:`Apptainer` binary in. Like in the
+      example above that could be your scratch folder. Once in the target
+      folder, run either of the the following commands to start the download:
+
+      .. code-block::
+
+         $ wget https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/apptainer/versions/miracl_v242.sif
       
-      .. attention::
-         ``singularity pull`` requires :program:`Singularity` version ``3.0.0`` 
-         or higher. Please refer to our 
-         :doc:`Troubleshooting section <../troubleshooting/troubleshooting_singularity>`
-         ("Can I build a Singularity container from the latest MIRACL 
-         image on Docker Hub") if you are using an older version of 
-         :program:`Singularity`.
-      
+      or
+
+      .. code-block::
+
+         $ curl -L -O https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/apptainer/versions/miracl_v242.sif
+
+      .. note::
+
+         Replace the version number with the version of MIRACL you want to download.
+
       .. raw:: html
 
          <h2>Interaction</h2>
@@ -489,17 +515,21 @@ either of the following methods:
       
       .. code-block::
 
-         $ singularity shell miracl_latest.sif bash
+         $ apptainer shell miracl_latest.sif bash
       
       Use the ``-B`` flag to bind a data directory to the container:
       
       .. code-block::
 
-         $ singularity shell -B /data:/data miracl_latest.sif bash
+         $ apptainer shell -B /data:/data miracl_latest.sif bash
+
+      Use the ``--nv`` flag to forward your Nvidia GPU into the container.
+
+         $ apptainer shell --nv -B /data:/data miracl_latest.sif bash
       
       .. SeeAlso::
          For running functions on clusters please check our 
-         :program:`Singularity` tutorials for Compute Canada and Sherlock
+         :program:`Apptainer` tutorials for Compute Canada and Sherlock
 
    .. tab:: Windows (WSL2)
 
@@ -604,7 +634,7 @@ either of the following methods:
       .. warning::
          Support for this installation method has been discontinued starting
          with version of ``2.2.6`` of :program:`MIRACL`. Please use :program:`Docker` 
-         or :program:`Singularity` instead.
+         or :program:`Apptainer` instead.
 
       .. warning::
          THIS INSTALLATION METHOD HAS BEEN DEPRECATED!

--- a/docs/installation/installation.rst
+++ b/docs/installation/installation.rst
@@ -505,7 +505,7 @@ either of the following methods:
 
       .. note::
 
-         Replace the version number with the version of MIRACL you want to download.
+         Replace the version number with the version of :program:`MIRACL` you want to download.
 
       .. raw:: html
 

--- a/docs/troubleshooting/index.rst
+++ b/docs/troubleshooting/index.rst
@@ -13,5 +13,5 @@ our `offical GitHub page <https://github.com/AICONSlab/MIRACL>`_.
    :caption: Table of contents:
 
    troubleshooting_docker
-   troubleshooting_singularity
+   troubleshooting_apptainer
    troubleshooting_local

--- a/docs/troubleshooting/troubleshooting_apptainer.rst
+++ b/docs/troubleshooting/troubleshooting_apptainer.rst
@@ -1,10 +1,10 @@
-Singularity
-###########
+Apptainer
+#########
 
 .. include:: ../directives/troubleshooting_icon_directive.rst
 
-|question| Can I build a Singularity container from the latest MIRACL image on Docker Hub
------------------------------------------------------------------------------------------
+|question| Can I build a Apptainer container from the latest MIRACL image on Docker Hub
+---------------------------------------------------------------------------------------
 
 Absolutely! To do so, however, you will need to grab a development node after 
 logging in to the cluster. If you try pulling from the login node, you will 
@@ -26,15 +26,15 @@ Once you have your node, you can then build the container:
 .. code-block::
 
    $ cd $SCRATCH
-   $ singularity build miracl_latest.sif docker://mgoubran/miracl:latest
+   $ apptainer build miracl_latest.sif docker://mgoubran/miracl:latest
 
 |question| Processes that require TrackVis or Diffusion Toolkit are not working
 -------------------------------------------------------------------------------
 
 .. include:: ../directives/trackvis_dtk_directive.rst
 
-|question| I get the following error whenever I try to run the GUI from within the Singularity container on Compute Canada
---------------------------------------------------------------------------------------------------------------------------
+|question| I get the following error whenever I try to run the GUI from within the Apptainer container on Compute Canada
+------------------------------------------------------------------------------------------------------------------------
 
 .. code-block::
 
@@ -48,16 +48,16 @@ terminal. You should use VNC instead. Follow the instructions
 `here <https://docs.alliancecan.ca/wiki/VNC>`_. Once you are connected to your 
 login or compute node with VNC, you will see a desktop environment. Open a 
 terminal there and follow :doc:`our tutorials <../tutorials/slurm/index>` on how 
-to use :program:`MIRACL` with :program:`Singularity` on clusters.
+to use :program:`MIRACL` with :program:`Apptainer` on clusters.
 
 If you for some reason need to run the :program:`MIRACL` GUI directly in the 
-terminal, using a :program:`Singularity` container and X11, try the following 
+terminal, using a :program:`Apptainer` container and X11, try the following 
 workarounds:
 
 Login Nodes
 ^^^^^^^^^^^
 
-Exit your :program:`Singularity` container and start a VNC server (for 3600sec 
+Exit your :program:`Apptainer` container and start a VNC server (for 3600sec 
 or more as required) on your login node:
 
 .. code-block::
@@ -76,13 +76,13 @@ username:
    If no socket is available for your username, log out and log back in to your 
    login node
 
-Start another :program:`Singularity` container and try to run ``miraclGUI`` 
+Start another :program:`Apptainer` container and try to run ``miraclGUI`` 
 again from within it.
 
 Compute Nodes
 ^^^^^^^^^^^^^
 
-Exit your :program:`Singularity` container and set an environment variable on 
+Exit your :program:`Apptainer` container and set an environment variable on 
 your allocated compute node:
 
 .. code-block::
@@ -95,5 +95,5 @@ Start a VNC server:
 
    vncserver
 
-Start another :program:`Singularity` container and try to run ``miraclGUI`` 
+Start another :program:`Apptainer` container and try to run ``miraclGUI`` 
 again from within it.

--- a/docs/tutorials/slurm/compute_canada/compute_canada.rst
+++ b/docs/tutorials/slurm/compute_canada/compute_canada.rst
@@ -108,7 +108,7 @@ Once you are logged in to the container, load the GUI from the shell:
    $ miraclGUI
 
 .. note::
-   Please consult our :doc:`Troubleshooting <../../../troubleshooting/troubleshooting_singularity>` 
+   Please consult our :doc:`Troubleshooting <../../../troubleshooting/troubleshooting_apptainer>` 
    section on :program:`Apptainer` if you experience problems with opening 
    :program:`MIRACL's` GUI on Compute Canada
 

--- a/docs/tutorials/slurm/compute_canada/compute_canada.rst
+++ b/docs/tutorials/slurm/compute_canada/compute_canada.rst
@@ -5,7 +5,7 @@ This tutorial highlights the registration workflow but a similar approach
 applies to other commands.
 
 When using Compute Canada, :program:`MIRACL` can be used as a 
-:program:`Apptainer/Singularity` container.
+:program:`Apptainer` container.
 
 Copy your data to Compute Canada
 ================================
@@ -37,82 +37,69 @@ Log in to the Compute Canada server you copied your data to:
 Setting up and using MIRACL
 ===========================
 
-Load the specific Apptainer/Singularity module you would like to use (e.g. Apptainer 1.2.4):
+Load the specific Apptainer module you would like to use (e.g. Apptainer 1.3.5):
 
 .. code-block::
 
-   $ module load apptainer/1.2.4
+   $ module load apptainer/1.3.5
 
 .. note::
    Not specifying the version will load the latest version available on your node
 
 Since :program:`MIRACL` will take up a significant amount of space, it is 
 recommended to download and work with the :program:`MIRACL` 
-:program:`Apptainer/Singularity` container in the scratch directory. First, navigate 
+:program:`Apptainer` container in the scratch directory. First, navigate 
 there:
 
 .. code-block::
    
    $ cd $SCRATCH
 
-Then pull (download) the :program:`Apptainer/Singularity` container:
+Then either build or directly download a :program:`MIRACL` :program:`Apptainer`
+container. For example, building the container would be done with:
 
 .. code-block::
 
-   $ apptainer pull miracl_latest.sif library://aiconslab/miracl/miracl:latest
+   $ apptainer build miracl_latest.sif docker://mgoubran/miracl:latest
 
-.. attention::  
+To download a :program:`MIRACL` Apptainer binary directly, do either of the 
+following:
 
-   If you encouter the following error with the pull command:  
+.. code-block::
 
-   .. code-block:: 
-   
-      FATAL:   Unable to get library client configuration: remote has no library client (see https://apptainer.org/docs/user/latest/endpoint.html#no-default-remote)  
+   $ wget https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/apptainer/versions/miracl_v242.sif
 
-   This error can be resolved by adding the default Apptainer end point from which the container is downloaded. Use:  
+or
 
-   .. code-block::  
+.. code-block::
 
-      apptainer remote add --no-login SylabsCloud cloud.sylabs.io  
-
-   then:  
-
-   .. code-block::  
-      
-      apptainer remote use SylabsCloud  
-
-   Now you should be able to pull the container using the commands described earlier.
-
-.. attention::
-
-   ``singularity pull`` requires :program:`Singularity` version ``3.0.0`` or 
-   higher. Please refer to our 
-   :doc:`Troubleshooting <../../../troubleshooting/index>` section ("Q: Can I 
-   build a Singularity container from the latest MIRACL image on Docker Hub") 
-   if you are using an older version of Singularity.
-
+   $ curl -L -O https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/apptainer/versions/miracl_v242.sif
 
 .. note::
 
-   If you have a particular Singularity container of :program:`MIRACL` that you 
-   want to use on Compute Canada, just copy it to the servers directly using 
-   e.g. ``scp`` or ``rsync`` instead of pulling (downloading) the latest 
-   version of :program:`MIRACL` from the :program:`Singularity` registry
+   Replace the version number with the version of MIRACL you want to download.
 
-Start the :program:`MIRACL` :program:`Apptainer/Singularity` container with the default 
+.. note::
+
+   If you have a particular :program:`Apptainer` container of :program:`MIRACL`
+   that you want to use on Compute Canada, just copy it to the servers directly 
+   using e.g. ``scp`` or ``rsync`` instead of building or downloading the latest 
+   version of :program:`MIRACL` from the :program:`Apptainer` registry
+
+Start the :program:`MIRACL` :program:`Apptainer` container with the default 
 folders mounted:
 
 .. code-block::
 
    $ apptainer shell miracl_latest.sif bash
 
-:program:`Singularity` will automatically mount your scratch folder to your 
+:program:`Apptainer` will automatically mount your scratch folder to your 
 container. If you need to mount a specific directory into a specific location, 
 use the following:
 
 .. code-block::
 
-   $ singularity shell -B <location_outside_container>/<source_mount>:<location_in_container>/<target_mount> miracl_latest.sif bash
+   $ apptainer shell -v <location_outside_container>/<source_mount>:<location_in_container>/<target_mount> miracl_latest.sif bash
 
 Once you are logged in to the container, load the GUI from the shell:
 
@@ -122,7 +109,7 @@ Once you are logged in to the container, load the GUI from the shell:
 
 .. note::
    Please consult our :doc:`Troubleshooting <../../../troubleshooting/troubleshooting_singularity>` 
-   section on :program:`Singularity` if you experience problems with opening 
+   section on :program:`Apptainer` if you experience problems with opening 
    :program:`MIRACL's` GUI on Compute Canada
 
 Or use :program:`MIRACL` from the command line. For example, run 
@@ -134,10 +121,10 @@ over previously:
    $ miracl flow reg_clar -f input_clar -n "-d 5 -ch autofluo" -r "-o ARS -m combined -v 25"
 
 .. note::
-   If you have a particular Singularity container of :program:`MIRACL` that you 
+   If you have a particular :program:`Apptainer` container of :program:`MIRACL` that you 
    want to use on Compute Canada, just copy it to the servers directly using 
    e.g. ``scp`` or ``rsync`` instead of pulling (downloading) the latest 
-   version of :program:`MIRACL` from the :program:`Singularity` registry
+   version of :program:`MIRACL` from the :program:`Apptainer` registry
 
 .. |linktoworkshop| replace:: :doc:`here <../../../downloads/workshops/2024/stanford_20_03_2024/stanford_20_03_2024>`
 

--- a/docs/tutorials/slurm/index.rst
+++ b/docs/tutorials/slurm/index.rst
@@ -2,9 +2,11 @@ HPC/SLURM clusters
 ##################
 
 :program:`MIRACL` was built with HPC/SLURM clusters in mind. We recommend 
-:program:`Singularity` as it is well suited to run in a cluster environment. 
-We provide a :program:`Singularity` container of :program:`MIRACL's` latest 
-version that can be pulled to a node directly from our online repo.
+:program:`Apptainer` as it is well suited to run in a cluster environment. 
+We provide an :program:`Apptainer` container of :program:`MIRACL's` latest 
+version that can be dowloaded to a node directly from our online repo.
+Alternatively, you can build an :program:`Apptainer` off of our 
+:program:`MIRACL` :program:`Docker` images hosted on DockerHub.
 
 We provide tutorials on how to use :program:`MIRACL` on Compute Canada and 
 Sherlock (supercomputer at Stanford university) but the principles explained 

--- a/docs/tutorials/slurm/sherlock/sherlock.rst
+++ b/docs/tutorials/slurm/sherlock/sherlock.rst
@@ -25,26 +25,38 @@ Move to your scratch folder:
 
    $ cd SCRATCH
 
-Pull (download) Singularity container:
+Build or download your :program:`MIRACL` container:
+
+Building from DockerHub image:
 
 .. code-block::
 
-   $ singularity pull miracl_latest.sif library://aiconslab/miracl/miracl:latest
+   $ apptainer build miracl.sif docker://mgoubran/miracl:latest
 
-.. attention::
+To download a :program:`MIRACL` Apptainer binary directly, use either of the 
+following commands:
 
-   ``singularity pull`` requires :program:`Singularity` version ``3.0.0`` or 
-   higher. Please refer to our Troubleshooting section ("Q: Can I build a 
-   :program:`Singularity` container from the latest MIRACL image on Docker 
-   Hub") if you are using an older version of :program:`Singularity`.
+.. code-block::
+
+$ wget https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/apptainer/versions/miracl_v242.sif
+
+or
+
+.. code-block::
+
+$ curl -L -O https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/apptainer/versions/miracl_v242.sif
+
+.. note::
+
+   Replace the version number with the version of MIRACL you want to download.
 
 .. tip::
 
-   If you have a particular :program:`Singularity` container of 
+   If you have a particular :program:`Apptainer` container of 
    :program:`MIRACL` that you want to use on Sherlock, just copy it to the 
    servers directly using e.g. :program:`scp` or :program:`rsync` instead of 
    pulling (downloading) the latest version of :program:`MIRACL` from the 
-   :program:`Singularity` registry
+   :program:`Apptainer` registry
 
 Copying your data to Sherlock
 =============================
@@ -86,11 +98,15 @@ Start interactive session:
 
    $ sdev
 
-Start :program:`Singularity` with binded data:
+Start :program:`Apptainer` with bound data:
 
 .. code-block::
 
-   $ singularity shell miracl_latest.sif bash
+   $ apptainer shell miracl_latest.sif bash
+
+.. note::
+   Use `--nv` to forward your Nvidia GPU into the container and `-B` to bind 
+   volumes to the container.
 
 Within the shell, load the GUI:
 
@@ -157,13 +173,13 @@ following lines:
    #SBATCH --cpus-per-task=12
    #SBATCH --mem=32G
 
-   module load singularity
+   module load apptainer
    
-   singularity exec ${SCRATCH}/miracl_latest.sif miracl flow reg_clar -f ${SCRATCH}/clarity_registration/input_clar -n "-d 5 -ch autofluo" -r "-o ARS -m combined -v 25"
+   apptainer exec ${SCRATCH}/miracl_latest.sif miracl flow reg_clar -f ${SCRATCH}/clarity_registration/input_clar -n "-d 5 -ch autofluo" -r "-o ARS -m combined -v 25"
 
 .. attention::
    Note that the ``miracl`` function call comes after invoking the 
-   :program:`Singularity` call ``singularity exec ${SCRATCH}/miracl_latest.sif`` 
+   :program:`Apptainer` call ``apptainer exec ${SCRATCH}/miracl_latest.sif`` 
    and that full file paths were used for the ``.sif`` container and the 
    input data
 

--- a/docs/tutorials/workflows/ace_flow/ace_flow.rst
+++ b/docs/tutorials/workflows/ace_flow/ace_flow.rst
@@ -377,7 +377,7 @@ Example of running ACE on single subject (Mode 2: Segmentation & Registration):
    you want to download. For this tutorial, you will need to
    download option ``1``.
 
-   Alternatively, download mode 2 sample data `here <https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_mode_2.zip>`_.
+   Alternatively, download mode 2 sample data `here <https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_mode_2.zip>`__.
 
 .. code-block::
 
@@ -421,7 +421,7 @@ Example of running ACE on one single subject (Mode 2: Segmentation Only):
    you want to download. For this tutorial, you will need to
    download option ``1``.
 
-   Alternatively, download mode 2 sample data `here <https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_mode_2.zip>`_.
+   Alternatively, download mode 2 sample data `here <https://huggingface.co/datasets/AICONSlab/MIRACL/resolve/dev/sample_data/ace/ace_sample_data_mode_2.zip>`__.
 
 .. code-block::
 

--- a/utility_scripts/download_sample_data
+++ b/utility_scripts/download_sample_data
@@ -13,7 +13,7 @@ This script downloads sample data required to run MIRACL's tutorials.
 Things to note:
 
 1) Please make sure that you are in the correct folder where you want to download the data to.
-2) Ideally this folder has been mounted into the Docker/Singularity container from the host system
+2) Ideally this folder has been mounted into the Docker/Apptainer container from the host system
 to ensure that the data won't be deleted when the container is shut down.
 
 Usage: $0 [-h]


### PR DESCRIPTION
Now that ACE has been released, we need to be more agile to quickly respond to issues and user requests. The biggest bottleneck currently is building and uploading Singularity images. This requires a new token every month and we have a maximum traffic limit for builds that restricts our MIRACL releases to <5/month. In the longterm we need to find a better hosting solution and also a different way to build the sif files that does not come with restrictions. However, for now I am disabling the Singularity build/upload completely in the CircleCI workflow as a short term solution. This will make publishing new MIRACL releases easier and more agile but we will also have to manually build and upload Singularity images for the time being.

Don't approve this PR yet please. Instead, let's add the following here as well:
- [ ] new workflow for building and uploading Apptainer binaries
- [x] updated docs