### PR TITLE
[PR/fix/feat] fix Clarity Allen registration

### DIFF
--- a/miracl/reg/cli_reg.py
+++ b/miracl/reg/cli_reg.py
@@ -6,115 +6,166 @@ from miracl.reg import miracl_reg_check_results
 
 
 def run_clar_allen(parser, args):
-    miracl_home = os.environ['MIRACL_HOME']
+    miracl_home = os.environ["MIRACL_HOME"]
     args = vars(args)
 
-    if len(sys.argv) == 3 and sys.argv[-2] == 'reg' and sys.argv[-1] == 'clar_allen':
-        subprocess.Popen('%s/reg/miracl_reg_clar-allen.sh' % miracl_home,
-                         shell=True)
+    if len(sys.argv) == 3 and sys.argv[-2] == "reg" and sys.argv[-1] == "clar_allen":
+        subprocess.Popen("%s/reg/miracl_reg_clar-allen.sh" % miracl_home, shell=True)
     else:
-        if args['help']:
-            subprocess.Popen('%s/reg/miracl_reg_clar-allen.sh -h' % miracl_home,
-                             shell=True)
+        if args["help"]:
+            subprocess.Popen(
+                "%s/reg/miracl_reg_clar-allen.sh -h" % miracl_home, shell=True
+            )
         else:
-            bash_args = '-i %s -r %s -o %s -m %s -v %s -l %s -f %s -p %s -a %s -w %s -b %s -s %s -c %s' \
-                        % (args['in_nii'],   # -i
-                           args['reg_out'],  # -r
-                           args['ort'],      # -o
-                           args['hemi'],     # -m
-                           args['vox_res'],  # -v
-                           args['lbls'],     # -l
-                           args['fig'],      # -f
-                           args['pass_int'], # -p
-                           args['atlas'],    # -a
-                           args['warp'],     # -w
-                           args['bulb'],     # -b
-                           args['side'],     # -s
-                           args['clar_dir']  # -c
-                           )
+            bash_args = (
+                "-i %s -r %s -o %s -m %s -v %s -l %s -f %s -p %s -a %s -w %s -b %s -s %s -c %s -n %s -x %s"
+                % (
+                    args["in_nii"],  # -i
+                    args["reg_out"],  # -r
+                    args["ort"],  # -o
+                    args["hemi"],  # -m
+                    args["vox_res"],  # -v
+                    args["lbls"],  # -l
+                    args["fig"],  # -f
+                    args["pass_int"],  # -p
+                    args["atlas"],  # -a
+                    args["warp"],  # -w
+                    args["bulb"],  # -b
+                    args["side"],  # -s
+                    args["clar_dir"],  # -c
+                    args["cn"],  # -n
+                    args["cp"],  # -x
+                )
+            )
 
-            subprocess.check_call('%s/reg/miracl_reg_clar-allen.sh %s' % (miracl_home, bash_args),
-                                  shell=True,
-                                  stderr=subprocess.STDOUT)
+            subprocess.check_call(
+                "%s/reg/miracl_reg_clar-allen.sh %s" % (miracl_home, bash_args),
+                shell=True,
+                stderr=subprocess.STDOUT,
+            )
 
 
 def run_mri_allen_ants(parser, args):
-    miracl_home = os.environ['MIRACL_HOME']
+    miracl_home = os.environ["MIRACL_HOME"]
     args = vars(args)
 
-    if sys.argv[-2] == 'reg' and sys.argv[-1] == 'mri_allen_ants':
-        subprocess.Popen('%s/reg/miracl_reg_mri-allen.sh' % miracl_home,
-                         shell=True)
+    if sys.argv[-2] == "reg" and sys.argv[-1] == "mri_allen_ants":
+        subprocess.Popen("%s/reg/miracl_reg_mri-allen.sh" % miracl_home, shell=True)
     else:
-        if args['help']:
-            subprocess.Popen('%s/reg/miracl_reg_mri-allen.sh -h' % miracl_home,
-                             shell=True)
+        if args["help"]:
+            subprocess.Popen(
+                "%s/reg/miracl_reg_mri-allen.sh -h" % miracl_home, shell=True
+            )
         else:
-            bash_args = '-i %s -o %s -m %s -v %s -l %s -b %s -s %s -f %s' \
-                        % (args['in_nii'], args['ort'], args['hemi'], args['vox_res'], args['lbls'], args['bulb'],
-                           args['skull'], args['bet'])
+            bash_args = "-i %s -o %s -m %s -v %s -l %s -b %s -s %s -f %s" % (
+                args["in_nii"],
+                args["ort"],
+                args["hemi"],
+                args["vox_res"],
+                args["lbls"],
+                args["bulb"],
+                args["skull"],
+                args["bet"],
+            )
 
-            subprocess.check_call('%s/reg/miracl_reg_mri-allen.sh %s' % (miracl_home, bash_args), shell=True,
-                                  stderr=subprocess.STDOUT)
+            subprocess.check_call(
+                "%s/reg/miracl_reg_mri-allen.sh %s" % (miracl_home, bash_args),
+                shell=True,
+                stderr=subprocess.STDOUT,
+            )
 
 
 def run_mri_allen_nifty(parser, args):
-    miracl_home = os.environ['MIRACL_HOME']
+    miracl_home = os.environ["MIRACL_HOME"]
     args = vars(args)
 
-    if sys.argv[-2] == 'reg' and sys.argv[-1] == 'mri_allen_nifty':
-        subprocess.Popen('%s/reg/miracl_reg_mri-allen_niftyreg.sh' % miracl_home,
-                         shell=True)
+    if sys.argv[-2] == "reg" and sys.argv[-1] == "mri_allen_nifty":
+        subprocess.Popen(
+            "%s/reg/miracl_reg_mri-allen_niftyreg.sh" % miracl_home, shell=True
+        )
     else:
-        if args['help']:
-            subprocess.Popen('%s/reg/miracl_reg_mri-allen_niftyreg.sh -h' % miracl_home,
-                             shell=True)
+        if args["help"]:
+            subprocess.Popen(
+                "%s/reg/miracl_reg_mri-allen_niftyreg.sh -h" % miracl_home, shell=True
+            )
         else:
-            bash_args = '-i %s -o %s -m %s -v %s -l %s -b %s -s %s -f %s' \
-                        % (args['in_nii'], args['ort'], args['hemi'], args['vox_res'], args['lbls'], args['bulb'],
-                           args['skull'], args['bet'])
+            bash_args = "-i %s -o %s -m %s -v %s -l %s -b %s -s %s -f %s" % (
+                args["in_nii"],
+                args["ort"],
+                args["hemi"],
+                args["vox_res"],
+                args["lbls"],
+                args["bulb"],
+                args["skull"],
+                args["bet"],
+            )
 
-            subprocess.check_call('%s/reg/miracl_reg_mri-allen_niftyreg.sh %s' % (miracl_home, bash_args), shell=True,
-                                  stderr=subprocess.STDOUT)
+            subprocess.check_call(
+                "%s/reg/miracl_reg_mri-allen_niftyreg.sh %s" % (miracl_home, bash_args),
+                shell=True,
+                stderr=subprocess.STDOUT,
+            )
 
 
 def run_warp_clar(parser, args):
-    miracl_home = os.environ['MIRACL_HOME']
+    miracl_home = os.environ["MIRACL_HOME"]
     args = vars(args)
 
-    if sys.argv[-2] == 'reg' and sys.argv[-1] == 'warp_clar':
-        subprocess.Popen('%s/reg/miracl_reg_warp_clar_data_to_allen.sh' % miracl_home,
-                         shell=True)
+    if sys.argv[-2] == "reg" and sys.argv[-1] == "warp_clar":
+        subprocess.Popen(
+            "%s/reg/miracl_reg_warp_clar_data_to_allen.sh" % miracl_home, shell=True
+        )
     else:
-        if args['help']:
-            subprocess.Popen('%s/reg/miracl_reg_warp_clar_data_to_allen.sh -h' % miracl_home,
-                             shell=True)
+        if args["help"]:
+            subprocess.Popen(
+                "%s/reg/miracl_reg_warp_clar_data_to_allen.sh -h" % miracl_home,
+                shell=True,
+            )
         else:
-            bash_args = '-i %s -o %s -r %s -s %s -v %s -l %s' % (
-                args['in_nii'], args['ort_file'], args['reg_dir'], args['seg_chan'], args['vox_res'], args['lbls'])
+            bash_args = "-i %s -o %s -r %s -s %s -v %s -l %s" % (
+                args["in_nii"],
+                args["ort_file"],
+                args["reg_dir"],
+                args["seg_chan"],
+                args["vox_res"],
+                args["lbls"],
+            )
 
-            subprocess.check_call('%s/reg/miracl_reg_warp_clar_data_to_allen.sh %s' % (miracl_home, bash_args),
-                                  shell=True,
-                                  stderr=subprocess.STDOUT)
+            subprocess.check_call(
+                "%s/reg/miracl_reg_warp_clar_data_to_allen.sh %s"
+                % (miracl_home, bash_args),
+                shell=True,
+                stderr=subprocess.STDOUT,
+            )
 
 
 def run_warp_mr(parser, args):
-    miracl_home = os.environ['MIRACL_HOME']
+    miracl_home = os.environ["MIRACL_HOME"]
     args = vars(args)
 
-    if sys.argv[-2] == 'reg' and sys.argv[-1] == 'warp_mr':
-        subprocess.Popen('%s/reg/miracl_reg_warp_mr_data_to_allen.sh' % miracl_home,
-                         shell=True)
+    if sys.argv[-2] == "reg" and sys.argv[-1] == "warp_mr":
+        subprocess.Popen(
+            "%s/reg/miracl_reg_warp_mr_data_to_allen.sh" % miracl_home, shell=True
+        )
     else:
-        if args['help']:
-            subprocess.Popen('%s/reg/miracl_reg_warp_mr_data_to_allen.sh -h' % miracl_home,
-                             shell=True)
+        if args["help"]:
+            subprocess.Popen(
+                "%s/reg/miracl_reg_warp_mr_data_to_allen.sh -h" % miracl_home,
+                shell=True,
+            )
         else:
-            bash_args = '-i %s -o %s -r %s' % (args['in_nii'], args['ort_file'], args['reg_dir'])
+            bash_args = "-i %s -o %s -r %s" % (
+                args["in_nii"],
+                args["ort_file"],
+                args["reg_dir"],
+            )
 
-            subprocess.check_call('%s/reg/miracl_reg_warp_mr_data_to_allen.sh %s' % (miracl_home, bash_args),
-                                  shell=True,
-                                  stderr=subprocess.STDOUT)
+            subprocess.check_call(
+                "%s/reg/miracl_reg_warp_mr_data_to_allen.sh %s"
+                % (miracl_home, bash_args),
+                shell=True,
+                stderr=subprocess.STDOUT,
+            )
 
 
 def run_check_reg(parser, args):
@@ -126,121 +177,166 @@ def get_parser():
     subparsers = parser.add_subparsers()
 
     # clar allen
-    parser_clar_allen = subparsers.add_parser('clar_allen', add_help=False,
-                                                 help="whole-brain CLARITY registration to Allen atlas")
-    parser_clar_allen.add_argument('-i', '--in_nii', metavar='',
-                                      help="input nifti")
-    parser_clar_allen.add_argument('-r', '--reg_out', metavar='', default=os.path.abspath(os.getcwd()),
-                                      help="output registration dir")
-    parser_clar_allen.add_argument('-o', '--ort', metavar='', default='ARS',
-                                      help="orientation tag")
-    parser_clar_allen.add_argument('-m', '--hemi', metavar='', default='combined',
-                                      help="whole brain or hemi")
-    parser_clar_allen.add_argument('-v', '--vox_res', metavar='', default=10,
-                                      help="voxel resolution")
-    parser_clar_allen.add_argument('-b', '--bulb', metavar='', default=0,
-                                      help="olfactory bulb included in brain, binary option")
-    parser_clar_allen.add_argument('-s', '--side', metavar='',
-                                      help="voxel resolution")
-    parser_clar_allen.add_argument('-a', '--atlas', metavar='',
-                                      help="custom atlas")
-    parser_clar_allen.add_argument('-l', '--lbls', metavar='',
-                                      help="custom labels")
-    parser_clar_allen.add_argument('-p', '--pass_int', metavar='', default=0,
-                                      help="skip intensity correction")
-    parser_clar_allen.add_argument('-f', '--fig', metavar='', default=1,
-                                      help="save mosaic figure of results")
-    parser_clar_allen.add_argument('-w', '--warp', metavar='', default=0,
-                                      help="warp high resolution clarity")
-    parser_clar_allen.add_argument('-c', '--clar_dir', metavar='', default='',
-                                      help="original clarity tiff folder")
-    parser_clar_allen.add_argument('-h', '--help', action='store_true')
+    parser_clar_allen = subparsers.add_parser(
+        "clar_allen",
+        add_help=False,
+        help="whole-brain CLARITY registration to Allen atlas",
+    )
+    parser_clar_allen.add_argument("-i", "--in_nii", metavar="", help="input nifti")
+    parser_clar_allen.add_argument(
+        "-r",
+        "--reg_out",
+        metavar="",
+        default=os.path.abspath(os.getcwd()),
+        help="output registration dir",
+    )
+    parser_clar_allen.add_argument(
+        "-o", "--ort", metavar="", default="ARS", help="orientation tag"
+    )
+    parser_clar_allen.add_argument(
+        "-m", "--hemi", metavar="", default="combined", help="whole brain or hemi"
+    )
+    parser_clar_allen.add_argument(
+        "-v", "--vox_res", metavar="", default=10, help="voxel resolution"
+    )
+    parser_clar_allen.add_argument(
+        "-b",
+        "--bulb",
+        metavar="",
+        default=0,
+        help="olfactory bulb included in brain, binary option",
+    )
+    parser_clar_allen.add_argument("-s", "--side", metavar="", help="voxel resolution")
+    parser_clar_allen.add_argument("-a", "--atlas", metavar="", help="custom atlas")
+    parser_clar_allen.add_argument("-l", "--lbls", metavar="", help="custom labels")
+    parser_clar_allen.add_argument(
+        "-p", "--pass_int", metavar="", default=0, help="skip intensity correction"
+    )
+    parser_clar_allen.add_argument(
+        "-f", "--fig", metavar="", default=1, help="save mosaic figure of results"
+    )
+    parser_clar_allen.add_argument(
+        "-w", "--warp", metavar="", default=0, help="warp high resolution clarity"
+    )
+    parser_clar_allen.add_argument(
+        "-c", "--clar_dir", metavar="", default="", help="original clarity tiff folder"
+    )
+    parser_clar_allen.add_argument(
+        "-n",
+        "--cn",
+        metavar="",
+        default="",
+        help="Chan # for extracting single channel from multiple channel data (default: Null)",
+    )
+    parser_clar_allen.add_argument(
+        "-x",
+        "--cp",
+        metavar="",
+        default="",
+        help="Chan prefix (string before channel number in file name). ex: C00",
+    )
+    parser_clar_allen.add_argument("-h", "--help", action="store_true")
 
     parser_clar_allen.set_defaults(func=run_clar_allen)
 
     # mri allen ants
-    parser_mri_allen = subparsers.add_parser('mri_allen_ants', add_help=False,
-                                             help="MRI registration to Allen atlas using ANTs")
-    parser_mri_allen.add_argument('-i', '--in_nii', metavar='',
-                                  help="input nifti")
-    parser_mri_allen.add_argument('-o', '--ort', metavar='',
-                                  help="orientation tag")
-    parser_mri_allen.add_argument('-m', '--hemi', metavar='',
-                                  help="whole brain or hemi")
-    parser_mri_allen.add_argument('-v', '--vox_res', metavar='',
-                                  help="voxel resolution")
-    parser_mri_allen.add_argument('-l', '--lbls', metavar='',
-                                  help="input labels")
-    parser_mri_allen.add_argument('-b', '--bulb', metavar='',
-                                  help="olfactory bulb")
-    parser_mri_allen.add_argument('-s', '--skull', metavar='',
-                                  help="skull strip")
-    parser_mri_allen.add_argument('-f', '--bet', metavar='',
-                                  help="bet fractional intensity")
-    parser_mri_allen.add_argument('-h', '--help', action='store_true')
+    parser_mri_allen = subparsers.add_parser(
+        "mri_allen_ants",
+        add_help=False,
+        help="MRI registration to Allen atlas using ANTs",
+    )
+    parser_mri_allen.add_argument("-i", "--in_nii", metavar="", help="input nifti")
+    parser_mri_allen.add_argument("-o", "--ort", metavar="", help="orientation tag")
+    parser_mri_allen.add_argument(
+        "-m", "--hemi", metavar="", help="whole brain or hemi"
+    )
+    parser_mri_allen.add_argument(
+        "-v", "--vox_res", metavar="", help="voxel resolution"
+    )
+    parser_mri_allen.add_argument("-l", "--lbls", metavar="", help="input labels")
+    parser_mri_allen.add_argument("-b", "--bulb", metavar="", help="olfactory bulb")
+    parser_mri_allen.add_argument("-s", "--skull", metavar="", help="skull strip")
+    parser_mri_allen.add_argument(
+        "-f", "--bet", metavar="", help="bet fractional intensity"
+    )
+    parser_mri_allen.add_argument("-h", "--help", action="store_true")
 
     parser_mri_allen.set_defaults(func=run_mri_allen_ants)
 
     # mri allen nifty
-    parser_mri_allen_nifty = subparsers.add_parser('mri_allen_nifty', add_help=False,
-                                                   help="MRI registration to Allen atlas using NiftyReg")
-    parser_mri_allen_nifty.add_argument('-i', '--in_nii', metavar='',
-                                        help="input nifti")
-    parser_mri_allen_nifty.add_argument('-o', '--ort', metavar='',
-                                        help="orientation tag")
-    parser_mri_allen_nifty.add_argument('-m', '--hemi', metavar='',
-                                        help="whole brain or hemi")
-    parser_mri_allen_nifty.add_argument('-v', '--vox_res', metavar='',
-                                        help="voxel resolution")
-    parser_mri_allen_nifty.add_argument('-l', '--lbls', metavar='',
-                                        help="input labels")
-    parser_mri_allen_nifty.add_argument('-b', '--bulb', metavar='',
-                                        help="olfactory bulb")
-    parser_mri_allen_nifty.add_argument('-s', '--skull', metavar='',
-                                        help="skull strip")
-    parser_mri_allen_nifty.add_argument('-f', '--bet', metavar='',
-                                        help="bet fractional intensity")
-    parser_mri_allen_nifty.add_argument('-h', '--help', action='store_true')
+    parser_mri_allen_nifty = subparsers.add_parser(
+        "mri_allen_nifty",
+        add_help=False,
+        help="MRI registration to Allen atlas using NiftyReg",
+    )
+    parser_mri_allen_nifty.add_argument(
+        "-i", "--in_nii", metavar="", help="input nifti"
+    )
+    parser_mri_allen_nifty.add_argument(
+        "-o", "--ort", metavar="", help="orientation tag"
+    )
+    parser_mri_allen_nifty.add_argument(
+        "-m", "--hemi", metavar="", help="whole brain or hemi"
+    )
+    parser_mri_allen_nifty.add_argument(
+        "-v", "--vox_res", metavar="", help="voxel resolution"
+    )
+    parser_mri_allen_nifty.add_argument("-l", "--lbls", metavar="", help="input labels")
+    parser_mri_allen_nifty.add_argument(
+        "-b", "--bulb", metavar="", help="olfactory bulb"
+    )
+    parser_mri_allen_nifty.add_argument("-s", "--skull", metavar="", help="skull strip")
+    parser_mri_allen_nifty.add_argument(
+        "-f", "--bet", metavar="", help="bet fractional intensity"
+    )
+    parser_mri_allen_nifty.add_argument("-h", "--help", action="store_true")
 
     parser_mri_allen_nifty.set_defaults(func=run_mri_allen_nifty)
 
     # warp clar
-    parser_warp_clar = subparsers.add_parser('warp_clar', add_help=False,
-                                             help="Warp CLARITY data to Allen space")
-    parser_warp_clar.add_argument('-i', '--in_nii', metavar='',
-                                  help="input nifti")
-    parser_warp_clar.add_argument('-r', '--reg_dir', metavar='',
-                                  help="registration dir")
-    parser_warp_clar.add_argument('-o', '--ort_file', metavar='',
-                                  help="file with ort tag")
-    parser_warp_clar.add_argument('-s', '--seg_chan', metavar='',
-                                  help="segmentation channel")
-    parser_warp_clar.add_argument('-v', '--vox_res', metavar='',
-                                  help="voxel resolution")
-    parser_warp_clar.add_argument('-l', '--lbls', metavar='',
-                                    help="labels")
-    parser_warp_clar.add_argument('-h', '--help', action='store_true')
+    parser_warp_clar = subparsers.add_parser(
+        "warp_clar", add_help=False, help="Warp CLARITY data to Allen space"
+    )
+    parser_warp_clar.add_argument("-i", "--in_nii", metavar="", help="input nifti")
+    parser_warp_clar.add_argument(
+        "-r", "--reg_dir", metavar="", help="registration dir"
+    )
+    parser_warp_clar.add_argument(
+        "-o", "--ort_file", metavar="", help="file with ort tag"
+    )
+    parser_warp_clar.add_argument(
+        "-s", "--seg_chan", metavar="", help="segmentation channel"
+    )
+    parser_warp_clar.add_argument(
+        "-v", "--vox_res", metavar="", help="voxel resolution"
+    )
+    parser_warp_clar.add_argument("-l", "--lbls", metavar="", help="labels")
+    parser_warp_clar.add_argument("-h", "--help", action="store_true")
 
     parser_warp_clar.set_defaults(func=run_warp_clar)
 
     # warp mr
-    parser_warp_mr = subparsers.add_parser('warp_mr', add_help=False,
-                                           help="Warp MRI data to Allen space")
-    parser_warp_mr.add_argument('-i', '--in_nii', metavar='',
-                                help="input nifti")
-    parser_warp_mr.add_argument('-r', '--reg_dir', metavar='',
-                                help="registration dir")
-    parser_warp_mr.add_argument('-o', '--ort_file', metavar='',
-                                help="file with ort tag")
-    parser_warp_mr.add_argument('-h', '--help', action='store_true')
+    parser_warp_mr = subparsers.add_parser(
+        "warp_mr", add_help=False, help="Warp MRI data to Allen space"
+    )
+    parser_warp_mr.add_argument("-i", "--in_nii", metavar="", help="input nifti")
+    parser_warp_mr.add_argument("-r", "--reg_dir", metavar="", help="registration dir")
+    parser_warp_mr.add_argument(
+        "-o", "--ort_file", metavar="", help="file with ort tag"
+    )
+    parser_warp_mr.add_argument("-h", "--help", action="store_true")
 
     parser_warp_mr.set_defaults(func=run_warp_mr)
 
     # check_reg
     check_reg_parser = miracl_reg_check_results.parsefn()
-    parser_check_reg = subparsers.add_parser('check', parents=[check_reg_parser], add_help=False,
-                                             usage=check_reg_parser.usage,
-                                             help="Check registration")
+    parser_check_reg = subparsers.add_parser(
+        "check",
+        parents=[check_reg_parser],
+        add_help=False,
+        usage=check_reg_parser.usage,
+        help="Check registration",
+    )
     parser_check_reg.set_defaults(func=run_check_reg)
 
     return parser
@@ -255,5 +351,5 @@ def main(args=None):
     args.func(parser, args)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/miracl/reg/cli_reg.py
+++ b/miracl/reg/cli_reg.py
@@ -225,14 +225,14 @@ def get_parser():
         "-n",
         "--cn",
         metavar="",
-        default="",
+        default="-999999",
         help="Chan # for extracting single channel from multiple channel data (default: Null)",
     )
     parser_clar_allen.add_argument(
         "-x",
         "--cp",
         metavar="",
-        default="",
+        default="-999999",
         help="Chan prefix (string before channel number in file name). ex: C00",
     )
     parser_clar_allen.add_argument("-h", "--help", action="store_true")

--- a/miracl/reg/miracl_reg_clar-allen.sh
+++ b/miracl/reg/miracl_reg_clar-allen.sh
@@ -915,7 +915,7 @@ function warpallenlbls() {
   firstlbl="${tifdirreg}"/lbls_slice_000000.tif
 
   # Create a series of 2D TIFF files, one for each slice in the original 3D stack
-  ifdsntexistrun "${firstlbl}" "Extracting tiff slices" c3d "${tiflblszstack}" -slice z 0:-1 -type ushort -oo "${tifdirreg}"/lbls_slice_%06d.tif
+  python /code/miracl/reg/miracl_reg_clar-allen_utility.py "${tiflblszstack}" "${tifdirreg}" "lbls_slice_%06d.tif"
 
   # Start loop from zero index
   loop_z=$(python -c "print(${orgclarz}-1)")

--- a/miracl/reg/miracl_reg_clar-allen.sh
+++ b/miracl/reg/miracl_reg_clar-allen.sh
@@ -836,13 +836,7 @@ function warpallenlbls() {
   # Print calculated downsampling factor
   # printf "\nUsing downsampling factor $df.\n"
 
-  # # get img dim
-  # alldim=$(PrintHeader ${inclar} 2)
-  # x=${alldim%%x*}
-  # yz=${alldim#*x}
-  # y=${yz%x*}
-  # z=${alldim##*x}
-
+  # get img dim
   alldim=$(PrintHeader "${inclar}" 2)
   IFS='x' read -ra dimensions <<<"$alldim"
   x="${dimensions[0]}"
@@ -869,12 +863,6 @@ function warpallenlbls() {
   # c3d ${tiflbls} -resample ${ox}x${oy}x${oz}mm -o ${restif}
 
   # get tiflbls dim
-  # tiflblsdim=$(PrintHeader ${tiflbls} 2)
-  # tiflblsx=${tiflblsdim%%x*}
-  # tiflblsyz=${tiflblsdim#*x}
-  # tiflblsy=${tiflblsyz%x*}
-  # z=${tiflblsdim##*x} ;
-
   tiflblsdim=$(PrintHeader reg_final/annotation_hemi_combined_10um_clar_vox.tif 2)
   IFS='x' read -ra dimensions <<<"$tiflblsdim"
   tiflblsx="${dimensions[0]}"
@@ -889,38 +877,21 @@ function warpallenlbls() {
 
   # get num slices (z dim)
   orgclar=$(realpath "${orgclar}")
-  # orgclarz=`ls ${orgclar}/*.tif* | wc -l`
-  # orgclarz=$(ls "${orgclar}"/*C01* | wc -l)
-  # firstslice=${orgclar}/$(ls ${orgclar} | head -n1)
-  # firstslice=$(ls "${orgclar}"/*C01* | head -n 1)
 
-  # Check if cn or cp are unset
-  if [[ -z "${cn}" && -z "${cp}" ]]; then
+  if [[ "${cn}" == "-999999" && "${cp}" == "-999999" ]]; then
     orgclarz=$(ls "${orgclar}"/*.tif* | wc -l)
     firstslice="${orgclar}/$(ls "${orgclar}" | head -n1)"
   else
     find_channel_files() {
-      local channel_pattern="${cp}${cn}"
-      find "${orgclar}" -maxdepth 1 -name "*${channel_pattern}*" "$@"
+        local channel_pattern="${cp}${cn}"
+        find "${orgclar}" -maxdepth 1 -name "*${channel_pattern}*" "$@"
     }
-
+    
     orgclarz=$(find_channel_files | wc -l)
     firstslice=$(find_channel_files -print | head -n 1)
   fi
 
-  # find_channel_files() {
-  #     local channel_pattern="${cp}${cn}"
-  #     find "${orgclar}" -maxdepth 1 -name "*${channel_pattern}*" "$@"
-  # }
-  #
-  # orgclarz=$(find_channel_files | wc -l)
-  # firstslice=$(find_channel_files -print | head -n 1)
-
   # get first_slice dim
-  # firstslicedim=$(PrintHeader ${firstslice} 2)
-  # firstslicex=${firstslicedim%%x*}
-  # firstslicey=${firstslicedim##*x}
-
   firstslicedim=$(PrintHeader "${firstslice}" 2)
   IFS='x' read -ra dimensions <<<"${firstslicedim}"
   firstslicex="${dimensions[0]}"

--- a/miracl/reg/miracl_reg_clar-allen.sh
+++ b/miracl/reg/miracl_reg_clar-allen.sh
@@ -1,18 +1,15 @@
 #!/usr/bin/env bash
 
 # get version
-function getversion()
-{
-	ver=`cat ${MIRACL_HOME}/version.txt`
-	printf "\n MIRACL pipeline v$ver \n"
+function getversion() {
+  ver=$(cat ${MIRACL_HOME}/version.txt)
+  printf "\n MIRACL pipeline v$ver \n"
 }
 
-
 # help/usage function
-function usage()
-{
-    
-    cat <<usage
+function usage() {
+
+  cat <<usage
 
 	1) Registers CLARITY data (down-sampled images) to Allen Reference mouse brain atlas
 	2) Warps Allen annotations to the original high-res CLARITY space
@@ -55,6 +52,9 @@ function usage()
         b.  olfactory bulb included in brain, binary option (default: 0 -> not included)
         p.  if utilfn intensity correction already run, skip correction inside registration (default: 0)
         w.  warp high-res clarity to Allen space (default: 0)
+        n.  Chan # for extracting single channel from multiple channel data (default: Null)
+        x.  Chan prefix (string before channel number in file name). ex: C00
+
 
 	----------
 	Main Outputs
@@ -74,295 +74,289 @@ function usage()
     -----------------------------------
 
 usage
-getversion >&2
+  getversion >&2
 
 }
 
 # Call help/usage function
-if [[ "$1" == "-h" || "$1" == "--help" || "$1" == "-help" ]]; then	
-        
-    usage >&2
-    exit 1
+if [[ "$1" == "-h" || "$1" == "--help" || "$1" == "-help" ]]; then
+
+  usage >&2
+  exit 1
 
 fi
-
 
 #----------
 
 # check dependencies
 
-if [[ -z ${MIRACL_HOME} ]];
-then
-    printf "\n ERROR: MIRACL not initialized .. please run init/setup_miracl.sh & rerun script \n"
-	exit 1
+if [[ -z ${MIRACL_HOME} ]]; then
+  printf "\n ERROR: MIRACL not initialized .. please run init/setup_miracl.sh & rerun script \n"
+  exit 1
 
 fi
 
-c3dpath=`which c3d`
+c3dpath=$(which c3d)
 if [[ -z ${c3dpath} ]]; then
-    printf "\n ERROR: c3d not initialized .. please setup miracl & rerun script \n"
-	exit 1
+  printf "\n ERROR: c3d not initialized .. please setup miracl & rerun script \n"
+  exit 1
 fi
 
 #----------
 
 # Init atlas dir
 
-atlasdir=$( dirname ${MIRACL_HOME} )/atlases
-
+atlasdir=$(dirname ${MIRACL_HOME})/atlases
 
 # GUI for CLARITY input imgs
 
-function choose_file_gui()
-{
-	local openstr=$1
-	local ftype=$2
-	local _inpath=$3
+function choose_file_gui() {
+  local openstr=$1
+  local ftype=$2
+  local _inpath=$3
 
-	filepath=$(${MIRACL_HOME}/conv/miracl_conv_file_folder_gui.py -f file -s "$openstr" -t "$ftype")
+  filepath=$(${MIRACL_HOME}/conv/miracl_conv_file_folder_gui.py -f file -s "$openstr" -t "$ftype")
 
-    filepath=`echo "${filepath}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//'`
+  filepath=$(echo "${filepath}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//')
 
-	eval ${_inpath}="'$filepath'"
+  eval ${_inpath}="'$filepath'"
 
 }
-
 
 # Select Mode : GUI or script
 
 if [[ "$#" -gt 1 ]]; then # $# > 1 means args are provided hence script mode is used
 
-	printf "\n Running in script mode \n"
+  printf "\n Running in script mode \n"
 
-	while getopts ":i:c:r:o:m:v:l:f:p:a:w:b:s:" opt; do
-    
-	    case "${opt}" in
+  while getopts ":i:c:r:o:m:v:l:f:p:a:w:b:s:n:x:" opt; do
 
-	      i)
-           inclar="${OPTARG}"
-           ;;
+    case "${opt}" in
 
-	      c)
-           orgclar="${OPTARG}"
-           ;;
+    i)
+      inclar="${OPTARG}"
+      ;;
 
-          r)
-          	work_dir="${OPTARG}"
-          	;;
+    c)
+      orgclar="${OPTARG}"
+      ;;
 
-          o)
-          	ort="${OPTARG}"
-          	;;
+    r)
+      work_dir="${OPTARG}"
+      ;;
 
-        	m)
-            hemi="${OPTARG}"
-            ;;
+    o)
+      ort="${OPTARG}"
+      ;;
 
-        	v)
-            vox="${OPTARG}"
-            ;;
+    m)
+      hemi="${OPTARG}"
+      ;;
 
-        	l)
-          	lbls="${OPTARG}"
-          	;;
+    v)
+      vox="${OPTARG}"
+      ;;
 
-          f)
-          	savefig="${OPTARG}"
-          	;;
+    l)
+      lbls="${OPTARG}"
+      ;;
 
-          p)
-            prebias="${OPTARG}"
-            ;;
+    f)
+      savefig="${OPTARG}"
+      ;;
 
-          a)
-          	atlas="${OPTARG}"
-          	;;
+    p)
+      prebias="${OPTARG}"
+      ;;
 
-          w)
-            warphres="${OPTARG}"
+    a)
+      atlas="${OPTARG}"
+      ;;
 
-            ;;
-          b)
-          	bulb="${OPTARG}"
-          	;;
+    w)
+      warphres="${OPTARG}"
 
-          s)
-          	side="${OPTARG}"
-			;;
+      ;;
+    b)
+      bulb="${OPTARG}"
+      ;;
 
-        	*)
-            usage            	
-            ;;
+    s)
+      side="${OPTARG}"
+      ;;
 
-		esac
-	
-	done    	
+    n)
+      cn="${OPTARG}"
+      ;;
 
+    x)
+      cp="${OPTARG}"
+      ;;
 
-	# check required input arguments
+    *)
+      usage
+      ;;
 
-	if [[ -z ${inclar} ]];
-	then
-		usage
-		echo "ERROR: < -i => input down-sampled clarity nii> not specified"
-		exit 1
-	fi
+    esac
 
-	if [[ -z ${orgclar} ]];
-	then
-		usage
-		echo "ERROR: < -c => input clarity tiff folder> not specified"
-		exit 1
-	fi
+  done
+
+  # check required input arguments
+
+  if [[ -z ${inclar} ]]; then
+    usage
+    echo "ERROR: < -i => input down-sampled clarity nii> not specified"
+    exit 1
+  fi
+
+  if [[ -z ${orgclar} ]]; then
+    usage
+    echo "ERROR: < -c => input clarity tiff folder> not specified"
+    exit 1
+  fi
 
 else
 
-	# call gui if no arguments are provided i.e. miraclGUI
+  # call gui if no arguments are provided i.e. miraclGUI
 
-	printf "\n No inputs given ... running in GUI mode \n"
+  printf "\n No inputs given ... running in GUI mode \n"
 
-	printf "\n Reading input data \n"
+  printf "\n Reading input data \n"
 
-	#choose_file_gui "Down-sampled auto-fluorescence (or Thy1) channel" "*.nii *.nii.gz" inclar
+  #choose_file_gui "Down-sampled auto-fluorescence (or Thy1) channel" "*.nii *.nii.gz" inclar
 
-	# options gui 
-	opts=$(${MIRACL_HOME}/conv/miracl_conv_gui_options.py -t "Reg options" -v "Down-sampled auto-fluorescence (or Thy1) channel"  \
-	-f  "Input clarity tiff folder (no default)" \
-		"Output directory (def = working dir)" "Orient code (def = ASL)" "Labels Hemi [combined (def)/split]" \
-        "Labels resolution [vox] (def = 10 'um')" "olfactory bulb incl. (def = 0)" "side (def = None)" \
-        "extra int correct (def = 0)" -hf "`usage`")
+  # options gui
+  opts=$("${MIRACL_HOME}"/conv/miracl_conv_gui_options.py -t "Reg options" -v "Down-sampled auto-fluorescence (or Thy1) channel" \
+    -f "Input clarity tiff folder (no default)" \
+    "Output directory (def = working dir)" "Orient code (def = ASL)" "Labels Hemi [combined (def)/split]" \
+    "Labels resolution [vox] (def = 10 'um')" "olfactory bulb incl. (def = 0)" "side (def = None)" \
+    "extra int correct (def = 0)" -hf "$(usage)")
 
-	# populate array
-	arr=()
-	while read -r line; do
-	   arr+=("$line")
-	done <<< "$opts"
+  # populate array
+  arr=()
+  while read -r line; do
+    arr+=("$line")
+  done <<<"$opts"
 
-    inclar=`echo "${arr[0]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//'`
+  inclar=$(echo "${arr[0]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//')
 
-    printf "\n Input file path: ${inclar} \n"
+  printf "\n Input file path: %s \n" "${inclar}"
 
-	# check required input arguments
+  # check required input arguments
 
-	if [[ -z ${inclar} ]] || [[ "${inclar}" == "No file was chosen" ]];
-	then
-		usage
-		echo "ERROR: <input clarity nii> was not chosen"
-		exit 1
-	fi
+  if [[ -z ${inclar} ]] || [[ "${inclar}" == "No file was chosen" ]]; then
+    usage
+    echo "ERROR: <input clarity nii> was not chosen"
+    exit 1
+  fi
 
-	if [[ -z ${orgclar} ]] || [[ "${orgclar}" == "No file was chosen" ]];
-	then
-		usage
-		echo "ERROR: <input clarity tiff folder> was not chosen"
-		exit 1
-	fi
+  if [[ -z ${orgclar} ]] || [[ "${orgclar}" == "No file was chosen" ]]; then
+    usage
+    echo "ERROR: <input clarity tiff folder> was not chosen"
+    exit 1
+  fi
 
-	orgclar=`echo "${arr[1]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//'`
+  orgclar=$(echo "${arr[1]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//')
 
-	printf "\n Chosen clarity tiff directory: $orgclar \n"
+  printf "\n Chosen clarity tiff directory: %s \n" "${orgclar}"
 
-	work_dir=`echo "${arr[2]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//'`
+  work_dir=$(echo "${arr[2]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//')
 
-    printf "\n Chosen output directory: $work_dir \n"
+  printf "\n Chosen output directory: %s \n" "${work_dir}"
 
-	ort=`echo "${arr[3]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//'`
+  ort=$(echo "${arr[3]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//')
 
-	printf "\n Chosen orient code: $ort \n"
+  printf "\n Chosen orient code: %s \n" "${ort}"
 
-	hemi=`echo "${arr[4]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//'`
+  hemi=$(echo "${arr[4]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//')
 
-	printf "\n Chosen labels hemi option: $hemi \n"
+  printf "\n Chosen labels hemi option: %s \n" "${hemi}"
 
-	vox=`echo "${arr[5]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//'`
+  vox=$(echo "${arr[5]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//')
 
-	printf "\n Chosen vox (um): $vox \n"
+  printf "\n Chosen vox (um): %s \n" "${vox}"
 
-	bulb=`echo "${arr[6]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//'`
+  bulb=$(echo "${arr[6]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//')
 
-    printf "\n Chosen olfactory bulb option: $bulb \n"
+  printf "\n Chosen olfactory bulb option: %s \n" "${bulb}"
 
-	side=`echo "${arr[7]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//'`
+  side=$(echo "${arr[7]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//')
 
-    printf "\n Chosen side option: $side \n"
+  printf "\n Chosen side option: %s \n" "${side}"
 
-    prebias=`echo "${arr[8]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//'`
+  prebias=$(echo "${arr[8]}" | cut -d ':' -f 2 | sed -e 's/^ "//' -e 's/"$//')
 
-    printf "\n Chosen extra intensity correct: $prebias \n"
-
+  printf "\n Chosen extra intensity correct: %s \n" "${prebias}"
 
 fi
-
 
 # make reg dir
 if [[ -z ${work_dir} ]] || [[ "${work_dir}" == "None" ]]; then
 
-    regdirfinal=${PWD}/reg_final
-    regdir=${PWD}/clar_allen_reg
+  regdirfinal=${PWD}/reg_final
+  regdir=${PWD}/clar_allen_reg
 
 else
 
-    regdirfinal=${work_dir}/reg_final
-    regdir=${work_dir}/clar_allen_reg
+  regdirfinal=${work_dir}/reg_final
+  regdir=${work_dir}/clar_allen_reg
 
 fi
 
 if [[ ! -d ${regdir} ]]; then
 
-    printf "\n Creating registration folder\n"
-    mkdir -p ${regdirfinal} ${regdir}
+  printf "\n Creating registration folder\n"
+  mkdir -p "${regdirfinal}" "${regdir}"
 
 fi
 
 # output log file of script
 
-exec > >(tee -i ${regdir}/clar_allen_script.log)
+exec > >(tee -i "${regdir}"/clar_allen_script.log)
 exec 2>&1
 
-
 #---------------------------
-
 
 # set defaults and assert (check for input errors)
 
 # orient code
 if [[ -z ${ort} ]] || [[ "${ort}" == "None" ]]; then
-    ort=ARS
+  ort=ARS
 fi
 ## if A-P flipped (PLS) & if R-L -> ALS
 
 # If want to warp multi-res / hemi lbls
 if [[ -z ${lbls} ]] || [[ "${lbls}" == "None" ]]; then
 
-    if [[ -z ${hemi} ]] || [[ "${hemi}" == "None" ]]; then
+  if [[ -z ${hemi} ]] || [[ "${hemi}" == "None" ]]; then
 
-        hemi=combined
+    hemi=combined
 
-    else
+  else
 
-        if [[ "${hemi}" != "combined" ]] && [[ "${hemi}" != "split" ]]; then
+    if [[ "${hemi}" != "combined" ]] && [[ "${hemi}" != "split" ]]; then
 
-            printf "ERROR: < -m => (hemi) > only takes as inputs: combined or split"
-            exit 1
-        fi
-
+      printf "ERROR: < -m => (hemi) > only takes as inputs: combined or split"
+      exit 1
     fi
 
-    if [[ -z ${vox} ]] || [[ "${vox}" == "None" ]]; then
+  fi
 
-        vox=10
+  if [[ -z ${vox} ]] || [[ "${vox}" == "None" ]]; then
 
-    else
+    vox=10
 
-        if [[ "${vox}" != 10 ]] && [[ "${vox}" != 25 ]] && [[ "${vox}" != 50 ]] ; then
+  else
 
-            printf "ERROR: < -v => (vox) > only takes as inputs: 10, 25 or 50"
-            exit 1
-        fi
+    if [[ "${vox}" != 10 ]] && [[ "${vox}" != 25 ]] && [[ "${vox}" != 50 ]]; then
 
+      printf "ERROR: < -v => (vox) > only takes as inputs: 10, 25 or 50"
+      exit 1
     fi
 
-    lbls=${atlasdir}/ara/annotation/annotation_hemi_${hemi}_${vox}um.nii.gz
+  fi
+
+  lbls=${atlasdir}/ara/annotation/annotation_hemi_${hemi}_${vox}um.nii.gz
 
 fi
 
@@ -376,77 +370,79 @@ fi
 
 # set side for hemisphere registration
 if [[ -z ${side} ]] || [[ "${side}" == "None" ]]; then
-    side=""
+  side=""
 elif [[ "${side}" == "rh" ]]; then
-    side="_right"
+  side="_right"
 elif [[ "${side}" == "lh" ]]; then
-    side="_left"
+  side="_left"
 else
-    printf "ERROR: < -s => (side) > only takes as inputs: rh or lh"
-    exit 1
+  printf "ERROR: < -s => (side) > only takes as inputs: rh or lh"
+  exit 1
 fi
 
-base=`basename ${lbls}`
-lblsname=${base%%.*};
+base=$(basename "${lbls}")
+lblsname=${base%%.*}
 
 # olfactory bulb
 if [[ -z ${bulb} ]] || [[ "${bulb}" == "None" ]]; then
-    bulb=0
+  bulb=0
 
-    # remove olfactory bulb from labels
-    custom_lbls=${regdir}/${lblsname}.nii.gz
-    c3d ${lbls} -replace 507 0 196 0 206 0 1016 0 204 0 900 0 665 0 698 0 -o ${custom_lbls}
+  # remove olfactory bulb from labels
+  custom_lbls=${regdir}/${lblsname}.nii.gz
+  c3d "${lbls}" -replace 507 0 196 0 206 0 1016 0 204 0 900 0 665 0 698 0 -o "${custom_lbls}"
 
-    if [[ "${hemi}" == "split" ]]; then
+  if [[ "${hemi}" == "split" ]]; then
 
-    	c3d ${custom_lbls} -replace 20507 0 20196 0 20206 0 3016 0 20204 0 20900 0 20665 0 20698 0 -o ${custom_lbls}
+    c3d "${custom_lbls}" -replace 20507 0 20196 0 20206 0 3016 0 20204 0 20900 0 20665 0 20698 0 -o "${custom_lbls}"
 
-    fi
-    	
-    lbls=${custom_lbls}
+  fi
+
+  lbls=${custom_lbls}
 
 else
 
-    if [[ "${bulb}" != 0 ]] && [[ "${bulb}" != 1 ]]; then
+  if [[ "${bulb}" != 0 ]] && [[ "${bulb}" != 1 ]]; then
 
     printf "ERROR: < -b = > (bulb) > only takes as inputs: 0 or 1"
     exit 1
 
-    fi
+  fi
 
 fi
 
 # pre-bias
 if [[ -z ${prebias} ]] || [[ "${prebias}" == "None" ]]; then
-    prebias=0
+  prebias=0
 fi
 
 # save mosaic
 if [[ -z ${savefig} ]] || [[ "${savefig}" == "None" ]]; then
-    savefig=1
+  savefig=1
 fi
 
 # warp high-res clar
 if [[ -z ${warphres} ]] || [[ "${warphres}" == "None" ]]; then
-    warphres=0
+  warphres=0
 fi
 
 # Print final args to screen for user
 printf "\n######################################################\n\n"
 printf "The following arguments will be used for registration:\n\n"
-printf "i: Down-sampled nii file: ${inclar}\n"
-printf "c: Clarity tiff folder: ${orgclar}\n"
-printf "r: Output directory: ${work_dir}\n"
-printf "o: Orientation code: ${ort}\n"
-printf "m: Hemisphere: ${hemi}\n"
-printf "v: Labels voxel: size${vox}\n"
-printf "b: Olfactory bulb included: ${bulb}\n"
-printf "s: Side: ${side}\n"
-printf "a: Custom Allen atlas: ${atlas}\n"
-printf "l: Allen labels to warp: ${lbls}\n"
-printf "p: Prebias: ${prebias}\n"
-printf "f: Save Mosaic figure: ${savefig}\n"
-printf "w: Warp high-res clarity to Allen space: ${warphres}\n"
+printf "i: Down-sampled nii file: %s\n" "${inclar}"
+printf "c: Clarity tiff folder: %s\n" "${orgclar}"
+printf "r: Output directory: %s\n" "${work_dir}"
+printf "o: Orientation code: %s\n" "${ort}"
+printf "m: Hemisphere: %s\n" "${hemi}"
+printf "v: Labels voxel: size%s\n" "${vox}"
+printf "b: Olfactory bulb included: %s\n" "${bulb}"
+printf "s: Side: %s\n" "${side}"
+printf "a: Custom Allen atlas: %s\n" "${atlas}"
+printf "l: Allen labels to warp: %s\n" "${lbls}"
+printf "p: Prebias: %s\n" "${prebias}"
+printf "f: Save Mosaic figure: %s\n" "${savefig}"
+printf "w: Warp high-res clarity to Allen space: %s\n" "${warphres}"
+printf "n: Channel #: %s\n" "${cn}"
+printf "x: Channel prefix: %s\n" "${cp}"
 printf "\n######################################################\n"
 
 # get time
@@ -460,124 +456,116 @@ START=$(date +%s)
 
 # Function to check if file exists then runs other command
 
-function ifdsntexistrun() 
-{  
+function ifdsntexistrun() {
 
-	local outfile="$1"; 
-	local outstr="$2"; 
-	local fun="${@:3}";  
+  local outfile="$1"
+  local outstr="$2"
+  local fun="${@:3}"
 
-	if [[ ! -f ${outfile} ]]; then
+  if [[ ! -f ${outfile} ]]; then
 
-		printf "\n $outstr \n"; 
-		echo "$fun"; 
-		eval "${fun}";
+    printf "\n %s \n" "${outstr}"
+    echo "$fun"
+    eval "${fun}"
 
-	else  
-		
-		printf "\n $outfile already exists ... skipping \n"; 
+  else
 
-	fi ; 
+    printf "\n %s already exists ... skipping \n" "${outfile}"
+
+  fi
 
 }
 
-
 # resample to 0.05mm voxel size
 
-function resampleclar()
-{
+function resampleclar() {
 
-	local inclar=$1
-	local vox=$2
-	local ifspacing=$3
-	local interp=$4
-	local resclar=$5
-	
-	ifdsntexistrun ${resclar} "Resampling CLARITY input" \
-	ResampleImage 3 ${inclar} ${resclar} ${vox}x${vox}x${vox} ${ifspacing} ${interp}
+  local inclar=$1
+  local vox=$2
+  local ifspacing=$3
+  local interp=$4
+  local resclar=$5
 
-	# c3d ${resclar} -type ushort -o ${resclar}
+  ifdsntexistrun "${resclar}" "Resampling CLARITY input" \
+    ResampleImage 3 "${inclar}" "${resclar}" "${vox}"x"${vox}"x"${vox}" "${ifspacing}" "${interp}"
+
+  # c3d ${resclar} -type ushort -o ${resclar}
 
 }
 
 # get brain mask (thresh & conn comp)
 
-function getbrainmask()
-{
-    local resclar=$1
-    local sharp=$2
-    local median=$3
-    local brain=$4
-    local mask=$5
-    local biasin=$6
-    local otsumaskthr=$7
-    local otsumask=$8
-    local otsucp=$9
-    local otsu=${10}
+function getbrainmask() {
+  local resclar=$1
+  local sharp=$2
+  local median=$3
+  local brain=$4
+  local mask=$5
+  local biasin=$6
+  local otsumaskthr=$7
+  local otsumask=$8
+  local otsucp=$9
+  local otsu=${10}
 
-    # sharpen
-    ifdsntexistrun ${sharp} "Sharpening image" ImageMath 3 ${sharp} Sharpen ${resclar}
+  # sharpen
+  ifdsntexistrun "${sharp}" "Sharpening image" ImageMath 3 "${sharp}" Sharpen "${resclar}"
 
-    # smooth
-    ifdsntexistrun ${median} "Median Filtering" SmoothImage 3 ${sharp} 2 ${median} 1 1
+  # smooth
+  ifdsntexistrun "${median}" "Median Filtering" SmoothImage 3 "${sharp}" 2 "${median}" 1 1
 
-    # bias correct in
-    ifdsntexistrun ${biasin} "Bias correcting input" N3BiasFieldCorrection 3 ${median} ${biasin} 2
-#    ifdsntexistrun ${biasin} "Bias correcting input" N4BiasFieldCorrection -i ${median} -o ${biasin} -s 2
+  # bias correct in
+  ifdsntexistrun "${biasin}" "Bias correcting input" N3BiasFieldCorrection 3 "${median}" "${biasin}" 2
+  #    ifdsntexistrun ${biasin} "Bias correcting input" N4BiasFieldCorrection -i ${median} -o ${biasin} -s 2
 
-    # Otsu threshold
-    ifdsntexistrun ${otsumaskthr} "Otsu thresholding" ThresholdImage 3 ${biasin} ${otsumaskthr} Otsu 6
+  # Otsu threshold
+  ifdsntexistrun "${otsumaskthr}" "Otsu thresholding" ThresholdImage 3 "${biasin}" "${otsumaskthr}" Otsu 6
 
-    # create mask
-#    ifdsntexistrun ${otsumask} "Thresholding mask" ThresholdImage 3 ${otsumaskthr} ${otsumask} 3 6
-    # ifdsntexistrun ${otsumask} "Thresholding mask" ThresholdImage 3 ${otsumaskthr} ${otsumask} 2 6
-	ifdsntexistrun ${otsumask} "Thresholding mask" ThresholdImage 3 ${otsumaskthr} ${otsumask} 1 6
+  # create mask
+  #    ifdsntexistrun ${otsumask} "Thresholding mask" ThresholdImage 3 ${otsumaskthr} ${otsumask} 3 6
+  # ifdsntexistrun ${otsumask} "Thresholding mask" ThresholdImage 3 ${otsumaskthr} ${otsumask} 2 6
+  ifdsntexistrun "${otsumask}" "Thresholding mask" ThresholdImage 3 "${otsumaskthr}" "${otsumask}" 1 6
 
-    # get masked
-#    ifdsntexistrun ${otsucp} "Create masked image" MultiplyImages 3 ${biasin} ${otsumask} ${otsucp} 1
-    ifdsntexistrun ${otsu} "Create masked image" MultiplyImages 3 ${biasin} ${otsumask} ${otsu} 1
+  # get masked
+  #    ifdsntexistrun ${otsucp} "Create masked image" MultiplyImages 3 ${biasin} ${otsumask} ${otsucp} 1
+  ifdsntexistrun "${otsu}" "Create masked image" MultiplyImages 3 "${biasin}" "${otsumask}" "${otsu}" 1
 
 }
 # N4 bias correct
 
-function biasfieldcorr()
-{
-	
-	local resclar=$1
-	local biasclar=$2
-	local mask=$3
+function biasfieldcorr() {
 
-    # make sure same clar & mask occupy same space
-    c3d ${resclar} ${mask} -copy-transform -o ${mask}
+  local resclar=$1
+  local biasclar=$2
+  local mask=$3
 
-	ifdsntexistrun ${biasclar} "Bias-correcting CLARITY image with N4" \
-	N4BiasFieldCorrection -d 3 -i ${resclar} -s 2 -t [0.15,0.01,200] -x ${mask} -o ${biasclar}
+  # make sure same clar & mask occupy same space
+  c3d "${resclar}" "${mask}" -copy-transform -o "${mask}"
+
+  ifdsntexistrun "${biasclar}" "Bias-correcting CLARITY image with N4" \
+    N4BiasFieldCorrection -d 3 -i "${resclar}" -s 2 -t [0.15,0.01,200] -x "${mask}" -o "${biasclar}"
 
 }
 
 # Extra field correct
 
-function extrabiasfieldcorr()
-{
+function extrabiasfieldcorr() {
 
-	local biasclar=$1
-	local mask=$2
+  local biasclar=$1
+  local mask=$2
 
-    printf"\n Performing extra bias correction step\n"
-    c3d ${biasclar} -as B -thresh 65% 75% 1 0 ${mask} -times -push B -times -scale 5 -push B -add -o ${biasclar}
-
+  printf"\n Performing extra bias correction step\n"
+  c3d "${biasclar}" -as B -thresh 65% 75% 1 0 "${mask}" -times -push B -times -scale 5 -push B -add -o "${biasclar}"
 
 }
 
 # Pad image
 
-function padimage()
-{
+function padimage() {
 
-    local biasclar=$1
-    local padclar=$2
+  local biasclar=$1
+  local padclar=$2
 
-    ifdsntexistrun ${padclar} "Padding image with 15% of voxels" c3d ${biasclar} -pad 15% 15% 0 -o ${padclar}
+  ifdsntexistrun "${padclar}" "Padding image with 15% of voxels" c3d "${biasclar}" -pad 15% 15% 0 -o "${padclar}"
 
 }
 
@@ -585,406 +573,432 @@ function padimage()
 
 # Thr
 
-function thresh()
-{
+function thresh() {
 
-	local biasclar=$1
-	local p1=$2  
-	local p2=$3
-	local t1=$4
-	local t2=$5
-	local thrclar=$6	
+  local biasclar=$1
+  local p1=$2
+  local p2=$3
+  local t1=$4
+  local t2=$5
+  local thrclar=$6
 
-	ifdsntexistrun ${thrclar} "Thresholding CLARITY image" \
-	c3d ${biasclar} -threshold ${p1}% ${p2}% ${t1} ${t2} -o ${thrclar}
+  ifdsntexistrun "${thrclar}" "Thresholding CLARITY image" \
+    c3d "${biasclar}" -threshold ${p1}% ${p2}% "${t1}" "${t2}" -o "${thrclar}"
 
 }
-
 
 # Ero
 
-function erode()
-{
-	
-	local thrclar=$1
-	local erorad=$2
-	local eromask=$3	
+function erode() {
 
-	ifdsntexistrun ${eromask} "Eroding CLARITY mask" ImageMath 3 ${eromask} ME ${thrclar} ${erorad}
+  local thrclar=$1
+  local erorad=$2
+  local eromask=$3
+
+  ifdsntexistrun "${eromask}" "Eroding CLARITY mask" ImageMath 3 "${eromask}" ME "${thrclar}" "${erorad}"
 
 }
-
 
 # Dil
 
-function dilate()
-{
-	
-	local eromask=$1
-	local dilrad=$2
-	local dilmask=$3
+function dilate() {
 
-	ifdsntexistrun ${dilmask} "Dilating CLARITY mask" ImageMath 3 ${dilmask} MD ${eromask} ${dilrad}
+  local eromask=$1
+  local dilrad=$2
+  local dilmask=$3
+
+  ifdsntexistrun "${dilmask}" "Dilating CLARITY mask" ImageMath 3 "${dilmask}" MD "${eromask}" "${dilrad}"
 
 }
-
 
 # mask
 
-function maskimage()
-{
-		
-	local biasclar=$1
-	local dilmask=$2
-	local betclar=$3
-		
-	ifdsntexistrun ${betclar} "Removing CLARITY image outline artifacts" \
-	MultiplyImages 3 ${biasclar} ${dilmask} ${betclar}
+function maskimage() {
+
+  local biasclar=$1
+  local dilmask=$2
+  local betclar=$3
+
+  ifdsntexistrun "${betclar}" "Removing CLARITY image outline artifacts" \
+    MultiplyImages 3 "${biasclar}" "${dilmask}" "${betclar}"
 
 }
 
+# Orient
 
-# Orient 
+function orientimg() {
 
-function orientimg()
-{
+  local betclar=$1
+  local orttag=$2
+  local ortint=$3
+  local orttype=$4
+  local ortclar=$5
 
-	local betclar=$1
-	local orttag=$2
-	local ortint=$3
-	local orttype=$4
-	local ortclar=$5
-
-	ifdsntexistrun ${ortclar} "Orienting CLARITY to standard orientation" \
-	c3d ${betclar} -orient ${orttag} -interpolation ${ortint} -type ${orttype} -o ${ortclar}
+  ifdsntexistrun "${ortclar}" "Orienting CLARITY to standard orientation" \
+    c3d "${betclar}" -orient "${orttag}" -interpolation "${ortint}" -type "${orttype}" -o "${ortclar}"
 
 }
-
 
 # Smooth image
 
-function smoothimg()
-{
-	
-	local ortclar=$1
-	local sigma=$2
-	local smclar=$3
+function smoothimg() {
 
-#	ifdsntexistrun ${smclar} "Smoothing CLARITY image" SmoothImage 3 ${ortclar} ${sigma} ${smclar} 1 1
-    ifdsntexistrun ${smclar} "Smoothing CLARITY image" c3d ${ortclar} -smooth ${sigma}vox -o ${smclar}
+  local ortclar=$1
+  local sigma=$2
+  local smclar=$3
 
+  #	ifdsntexistrun ${smclar} "Smoothing CLARITY image" SmoothImage 3 ${ortclar} ${sigma} ${smclar} 1 1
+  ifdsntexistrun "${smclar}" "Smoothing CLARITY image" c3d "${ortclar}" -smooth "${sigma}vox" -o "${smclar}"
 
 }
-
 
 # Crop to smallest roi
 
-function croptosmall()
-{
-	
-	local smclar=$1
-	local trim=$2
-	local clarroi=$3
+function croptosmall() {
 
-	ifdsntexistrun ${clarroi} "Cropping CLARITY image to smallest ROI" \
-	c3d ${smclar} -trim ${trim}vox -o ${clarroi}
-	# c3d ${smclar} -trim ${trim}vox -type ushort -o ${clarroi}
+  local smclar=$1
+  local trim=$2
+  local clarroi=$3
+
+  ifdsntexistrun "${clarroi}" "Cropping CLARITY image to smallest ROI" \
+    c3d "${smclar}" -trim "${trim}"vox -o "${clarroi}"
+  # c3d ${smclar} -trim ${trim}vox -type ushort -o ${clarroi}
 
 }
 
-
 #---------------------------
-
 
 # 2a) initialize registration Function
 
-function initclarallenreg()
-{
+function initclarallenreg() {
 
-	# Init imgs
-	clarroi=$1
-	allenref=$2
+  # Init imgs
+  clarroi=$1
+  allenref=$2
 
-	# Init tform
-	initform=$3
+  # Init tform
+  initform=$3
 
-	# Init parms
-	deg=$4
-	radfrac=$5
-	useprincax=$6
-	localiter=$7
-	
-	# Out imgs
-	initallen=$8
+  # Init parms
+  deg=$4
+  radfrac=$5
+  useprincax=$6
+  localiter=$7
 
+  # Out imgs
+  initallen=$8
 
-	# Init reg
-	ifdsntexistrun ${initform} "Initializing registration ..." \
-	 antsAffineInitializer 3 ${clarroi} ${allenref} ${initform} ${deg} ${radfrac} ${useprincax} ${localiter} 2> /dev/null &
+  # Init reg
+  ifdsntexistrun "${initform}" "Initializing registration ..." \
+    antsAffineInitializer 3 "${clarroi}" "${allenref}" "${initform}" "${deg}" "${radfrac}" "${useprincax}" "${localiter}" 2>/dev/null &
 
-    # kill after 3 min (gcc issue)
-    if [[ ! -f "${initallen}" ]] ; then
-        sleep 180
+  # kill after 3 min (gcc issue)
+  if [[ ! -f "${initallen}" ]]; then
+    sleep 180
 
-        kill -9 $(ps -e | grep antsAffineInit | awk '{print $1}')
-    fi
+    kill -9 $(ps -e | grep antsAffineInit | awk '{print $1}')
+  fi
 
-	# Warp Allen
-	ifdsntexistrun ${initallen} "initializing Allen template" \
-	 antsApplyTransforms -i ${allenref} -r ${clarroi} -t ${initform} -o ${initallen}
-
+  # Warp Allen
+  ifdsntexistrun "${initallen}" "initializing Allen template" \
+    antsApplyTransforms -i "${allenref}" -r "${clarroi}" -t "${initform}" -o "${initallen}"
 
 }
 
-
-
 #---------------------------
-
 
 # 2b) Register to Allen atlas Function
 
-function regclarallen()
-{
+function regclarallen() {
 
-	# Reg inputs
-	local clarroi=$1
-	local initallen=$2
+  # Reg inputs
+  local clarroi=$1
+  local initallen=$2
 
-	# Reg parms
-	local trans=$3	
-	local spldist=$4	
-	local rad=$5	
-	local prec=$6	
-	local thrds=$7
+  # Reg parms
+  local trans=$3
+  local spldist=$4
+  local rad=$5
+  local prec=$6
+  local thrds=$7
 
-	# Reg out
-	local antsallen=$8
+  # Reg out
+  local antsallen=$8
 
-    # convert init allen into int
-    c3d ${initallen} -type int -o ${initallen}
+  # convert init allen into int
+  c3d "${initallen}" -type int -o "${initallen}"
 
-	# Perform ANTs registration between CLARITY and Allen atlas
+  # Perform ANTs registration between CLARITY and Allen atlas
 
-	ifdsntexistrun ${antsallen} "Registering CLARITY data to allen atlas ... this will take a while" \
-	ants_miracl_clar -d 3 -f ${clarroi} -m ${initallen} -o ${regdir}/allen_clar_ants -t ${trans} -p ${prec} \
-	 -n ${thrds} -s ${spldist} -r ${rad} | tee ${regdir}/ants_reg.log
-
+  ifdsntexistrun "${antsallen}" "Registering CLARITY data to allen atlas ... this will take a while" \
+    ants_miracl_clar -d 3 -f "${clarroi}" -m "${initallen}" -o "${regdir}/allen_clar_ants" -t "${trans}" -p "${prec}" \
+    -n "${thrds}" -s "${spldist}" -r "${rad}" | tee "${regdir}"/ants_reg.log
 
 }
 
-
 #---------------------------
-
 
 # 3) Warp Allen labels to original CLARITY Function
 
+function warpallenlbls() {
 
-function warpallenlbls()
-{
-	
-	# In imgs
-	local smclar=$1
-	local lbls=$2
+  # In imgs
+  local smclar=$1
+  local lbls=$2
 
-	# In tforms
-	local antswarp=$3
-	local antsaff=$4
-	local initform=$5
+  # In tforms
+  local antswarp=$3
+  local antsaff=$4
+  local initform=$5
 
-	# Out lbls
-	local wrplbls=$6
-	
-	# Ort pars
-	local ortlbls=$7
+  # Out lbls
+  local wrplbls=$6
 
-	# swap lbls
-	local swplbls=$8
-	local tiflbls=$9
-	
-	# Up lbls
-    local inclar=${10}
-    local reslbls=${11}
-    local restif=${12}
+  # Ort pars
+  local ortlbls=$7
 
-    # Vox
-    local vox=${13}
+  # swap lbls
+  local swplbls=$8
+  local tiflbls=$9
 
-    # Res clar
-    local smclarres=${14}
+  # Up lbls
+  local inclar=${10}
+  local reslbls=${11}
+  local restif=${12}
 
-    # lbls to org nii
-    local inclar=${15}
-    local orgortlbls=${16}
-    local lblsorgnii=${17}
+  # Vox
+  local vox=${13}
 
-    local wrplblsorg=${18}
-    local unpadtif=${19}
+  # Res clar
+  local smclarres=${14}
 
+  # lbls to org nii
+  local inclar=${15}
+  local orgortlbls=${16}
+  local lblsorgnii=${17}
 
-    # lbls to high res tiff
-    local orgclar=${20}
-    local tiflblszstack=${21}
-    local tifdirreg=${22}
-    local tifdirregfinal=${23}
+  local wrplblsorg=${18}
+  local unpadtif=${19}
 
-    # orgclar, tiflbls_zstack , tifdir_reg, tifdir_regfinal 
+  # lbls to high res tiff
+  local orgclar=${20}
+  local tiflblszstack=${21}
+  local tifdirreg=${22}
+  local tifdirregfinal=${23}
 
+  # orgclar, tiflbls_zstack , tifdir_reg, tifdir_regfinal
 
-    # Upsample ref
-    vres=`python -c "print (${vox}/1000.0)"`
+  # Upsample ref
+  vres=$(python -c "print (${vox}/1000.0)")
 
-    # res clar in
-    ifdsntexistrun ${smclarres} "Upsampling reference image" \
-     ResampleImage 3 ${smclar} ${smclarres} ${vres}x${vres}x${vres} 0 3
+  # res clar in
+  ifdsntexistrun "${smclarres}" "Upsampling reference image" \
+    ResampleImage 3 "${smclar}" "${smclarres}" "${vres}"x"${vres}"x"${vres}" 0 3
 
-    # convert to ushort
-    # ConvertImagePixelType ${smclarres} ${smclarres} 3
-    # c3d ${smclarres} -type ushort -o ${smclarres}
+  # convert to ushort
+  # ConvertImagePixelType ${smclarres} ${smclarres} 3
+  # c3d ${smclarres} -type ushort -o ${smclarres}
 
-	# warp to registered clarity
-	ifdsntexistrun ${wrplbls} "Applying ants deformation to Allen labels" \
-    antsApplyTransforms -d 3 -r ${smclarres} -i ${lbls} -n MultiLabel -t ${antswarp} ${antsaff} ${initform} \
-    -o ${wrplbls} --float
+  # warp to registered clarity
+  ifdsntexistrun "${wrplbls}" "Applying ants deformation to Allen labels" \
+    antsApplyTransforms -d 3 -r "${smclarres}" -i "${lbls}" -n MultiLabel -t "${antswarp}" "${antsaff}" "${initform}" \
+    -o "${wrplbls}" --float
 
-    # get org tag
-	ortmatrix=`PrintHeader ${inclar} 4 | tr 'x' ' '`
+  # get org tag
+  ortmatrix=$(PrintHeader "${inclar}" 4 | tr 'x' ' ')
 
-	ifdsntexistrun ${ortlbls} "Orienting Allen labels" SetDirectionByMatrix ${wrplbls} ${ortlbls} ${ortmatrix}
+  ifdsntexistrun "${ortlbls}" "Orienting Allen labels" SetDirectionByMatrix "${wrplbls}" "${ortlbls}" "${ortmatrix}"
 
-	# swap dim (x=>y / y=>x)
-	# ifdsntexistrun ${swplbls} "Swapping label dimensions" \
-	 # PermuteFlipImageOrientationAxes 3 ${ortlbls} ${swplbls}  1 0 2  0 0 0
+  # swap dim (x=>y / y=>x)
+  # ifdsntexistrun ${swplbls} "Swapping label dimensions" \
+  # PermuteFlipImageOrientationAxes 3 ${ortlbls} ${swplbls}  1 0 2  0 0 0
 
-	ifdsntexistrun ${unpadtif} "Swapping label dimensions & converting to tif" \
-	 PermuteFlipImageOrientationAxes 3 ${ortlbls} ${unpadtif}  1 0 2  0 0 0
+  ifdsntexistrun "${unpadtif}" "Swapping label dimensions & converting to tif" \
+    PermuteFlipImageOrientationAxes 3 "${ortlbls}" "${unpadtif}" 1 0 2 0 0 0
 
-    # ifdsntexistrun ${tiflbls} "Un-padding high res tif" c3d ${unpadtif} -pad -15% -15% -o ${tiflbls}
+  # ifdsntexistrun ${tiflbls} "Un-padding high res tif" c3d ${unpadtif} -pad -15% -15% -o ${tiflbls}
 
-    if [[ "${vox}" == 10 ]]; then
-    	padvox=11.5 
-    else
-    	padvox=12
-    fi
+  if [[ "${vox}" == 10 ]]; then
+    padvox=11.5
+  else
+    padvox=12
+  fi
 
-    printf "\n pad vox: ${padvox} \n" 
+  printf "\n pad vox: "${padvox}" \n"
 
-    ifdsntexistrun ${tiflbls} "Un-padding high res tif" c3d ${unpadtif} -pad -${padvox}% -${padvox}% -o ${tiflbls}
+  ifdsntexistrun "${tiflbls}" "Un-padding high res tif" c3d "${unpadtif}" -pad -"${padvox}"% -"${padvox}"% -o "${tiflbls}"
 
-    # create hres tif lbls
+  # create hres tif lbls
 
-	# upsample to img dimensions
-    # df=`echo ${inclar} | egrep -o "[0-9]{2}x_down" | egrep -o "[0-9]{2}"`
+  # upsample to img dimensions
+  # df=`echo ${inclar} | egrep -o "[0-9]{2}x_down" | egrep -o "[0-9]{2}"`
 
-    # Print calculated downsampling factor
-    # printf "\nUsing downsampling factor $df.\n"
+  # Print calculated downsampling factor
+  # printf "\nUsing downsampling factor $df.\n"
 
-    # # get img dim
-    alldim=`PrintHeader ${inclar} 2`
-    x=${alldim%%x*} ;
-    yz=${alldim#*x} ; y=${yz%x*} ;
-    z=${alldim##*x} ;
+  # # get img dim
+  # alldim=$(PrintHeader ${inclar} 2)
+  # x=${alldim%%x*}
+  # yz=${alldim#*x}
+  # y=${yz%x*}
+  # z=${alldim##*x}
 
-    # # Print header dimensions
-    # printf "\nHeader dimensions:\nx = $x\ny = $y\nyz = $yz\nz = $z\n"
+  alldim=$(PrintHeader "${inclar}" 2)
+  IFS='x' read -ra dimensions <<<"$alldim"
+  x="${dimensions[0]}"
+  y="${dimensions[1]}"
+  z="${dimensions[2]}"
+  yz="${dimensions[1]}x${dimensions[2]}"
+  printf "\n alldim: %s\n" "${alldim}"
+  printf "  x: %s\n" "${x}"
+  printf "  y: %s\n" "${y}"
+  printf "  z: %s\n" "${z}"
+  printf "  yz: %s\n" "${yz}"
 
-    # ox=$(($y*$df)) ;
-    # oy=$(($x*$df)) ;
-    # oz=$(($z*$df)) ;
+  # # Print header dimensions
+  # printf "\nHeader dimensions:\nx = $x\ny = $y\nyz = $yz\nz = $z\n"
 
-    # # Print upsamle dimensions
-    # printf "\nUpsample dimensions:\nox = $ox\noy = $oy\noz = $oz\n"
+  # ox=$(($y*$df)) ;
+  # oy=$(($x*$df)) ;
+  # oz=$(($z*$df)) ;
 
-    # ifdsntexistrun ${restif} "Converting high res lbls to tif" \
-     # c3d ${tiflbls} -resample ${ox}x${oy}x${oz}mm -o ${restif}
+  # # Print upsamle dimensions
+  # printf "\nUpsample dimensions:\nox = $ox\noy = $oy\noz = $oz\n"
 
+  # ifdsntexistrun ${restif} "Converting high res lbls to tif" \
+  # c3d ${tiflbls} -resample ${ox}x${oy}x${oz}mm -o ${restif}
 
-    # get tiflbls dim
-    tiflblsdim=`PrintHeader ${tiflbls} 2`
-    tiflblsx=${tiflblsdim%%x*} ;
-    tiflblsyz=${tiflblsdim#*x} ; tiflblsy=${tiflblsyz%x*} ;
-    # z=${tiflblsdim##*x} ;
+  # get tiflbls dim
+  # tiflblsdim=$(PrintHeader ${tiflbls} 2)
+  # tiflblsx=${tiflblsdim%%x*}
+  # tiflblsyz=${tiflblsdim#*x}
+  # tiflblsy=${tiflblsyz%x*}
+  # z=${tiflblsdim##*x} ;
 
-    # get num slices (z dim)
-	orgclar=$(realpath ${orgclar})
-	orgclarz=`ls ${orgclar}/*.tif* | wc -l` 
-	firstslice=${orgclar}/`ls ${orgclar} | head -n1`
+  tiflblsdim=$(PrintHeader reg_final/annotation_hemi_combined_10um_clar_vox.tif 2)
+  IFS='x' read -ra dimensions <<<"$tiflblsdim"
+  tiflblsx="${dimensions[0]}"
+  tiflblsy="${dimensions[1]}"
+  tiflblsz="${dimensions[2]}"
+  tiflblsyz="${dimensions[1]}x${dimensions[2]}"
+  printf "  tiflblsdim: %s\n" "${tiflblsdim}"
+  printf "  tiflblsx: %s\n" "${tiflblsx}"
+  printf "  tiflblsy: %s\n" "${tiflblsy}"
+  printf "  tiflblsz: %s\n" "${tiflblsz}"
+  printf "  tiflblsyz: %s\n" "${tiflblsyz}"
 
-    # get first_slice dim
-    firstslicedim=`PrintHeader ${firstslice} 2`
-    firstslicex=${firstslicedim%%x*} ;
-    firstslicey=${firstslicedim##*x} ;
+  # get num slices (z dim)
+  orgclar=$(realpath "${orgclar}")
+  # orgclarz=`ls ${orgclar}/*.tif* | wc -l`
+  # orgclarz=$(ls "${orgclar}"/*C01* | wc -l)
+  # firstslice=${orgclar}/$(ls ${orgclar} | head -n1)
+  # firstslice=$(ls "${orgclar}"/*C01* | head -n 1)
 
+  # Check if cn or cp are unset
+  if [[ -z "${cn}" && -z "${cp}" ]]; then
+    orgclarz=$(ls "${orgclar}"/*.tif* | wc -l)
+    firstslice="${orgclar}/$(ls "${orgclar}" | head -n1)"
+  else
+    find_channel_files() {
+      local channel_pattern="${cp}${cn}"
+      find "${orgclar}" -maxdepth 1 -name "*${channel_pattern}*" "$@"
+    }
 
-    printf "\n orgclar: ${orgclar} \n" 
-	printf "\n orgclar z: ${orgclarz} \n"
+    orgclarz=$(find_channel_files | wc -l)
+    firstslice=$(find_channel_files -print | head -n 1)
+  fi
 
-    ifdsntexistrun ${tiflblszstack} "Resampling high res tif" ResampleImage 3 ${tiflbls} ${tiflblszstack} ${tiflblsx}x${tiflblsy}x${orgclarz} 1 1 3  
-    # 1- Spacing , 1- NN, 3- ushort
+  # find_channel_files() {
+  #     local channel_pattern="${cp}${cn}"
+  #     find "${orgclar}" -maxdepth 1 -name "*${channel_pattern}*" "$@"
+  # }
+  #
+  # orgclarz=$(find_channel_files | wc -l)
+  # firstslice=$(find_channel_files -print | head -n 1)
 
-	if [[ ! -d ${tifdirreg} ]]; then
-    	mkdir -p ${tifdirreg} ${tifdirregfinal} 
-    fi  
+  # get first_slice dim
+  # firstslicedim=$(PrintHeader ${firstslice} 2)
+  # firstslicex=${firstslicedim%%x*}
+  # firstslicey=${firstslicedim##*x}
 
+  firstslicedim=$(PrintHeader "${firstslice}" 2)
+  IFS='x' read -ra dimensions <<<"${firstslicedim}"
+  firstslicex="${dimensions[0]}"
+  firstslicey="${dimensions[1]}"
+  printf "  orgclarz: %s\n" "${orgclarz}"
+  printf "  firstslice: %s\n" "${firstslice}"
+  printf "  firstslicedim: %s\n" "${firstslicedim}"
+  printf "  firstslicex: %s\n" "${firstslicex}"
+  printf "  firstslicey: %s\n" "${firstslicey}"
 
-    firstlbl=${tifdirreg}/lbls_slice_000000.tif
+  printf "\n orgclar: %s \n" "${orgclar}"
+  printf "\n orgclar z: %s \n" "${orgclarz}"
 
-    ifdsntexistrun ${firstlbl} "Extracting tiff slices" c3d ${tiflblszstack} -slice z 0:-1 -type ushort -oo ${tifdirreg}/lbls_slice_%06d.tif
+  ifdsntexistrun "${tiflblszstack}" "Resampling high res tif" ResampleImage 3 "${tiflbls}" "${tiflblszstack}" "${tiflblsx}"x"${tiflblsy}"x"${orgclarz}" 1 1 3
+  # 1- Spacing , 1- NN, 3- ushort
 
-    loop_z=$(python -c "print(${orgclarz}-1)")
+  if [[ ! -d "${tifdirreg}" ]]; then
+    mkdir -p "${tifdirreg}" "${tifdirregfinal}"
+  fi
 
+  firstlbl="${tifdirreg}"/lbls_slice_000000.tif
 
-    firstlblclar=${tifdirregfinal}/lbls_clar_slice_000000.tif
+  # Create a series of 2D TIFF files, one for each slice in the original 3D stack
+  ifdsntexistrun "${firstlbl}" "Extracting tiff slices" c3d "${tiflblszstack}" -slice z 0:-1 -type ushort -oo "${tifdirreg}"/lbls_slice_%06d.tif
 
-    printf "\n firstslice: ${firstslice} \n" 
-    printf "\n firstslice x: ${firstslicex} \n"
-    printf "\n firstslice y: ${firstslicey} \n"
+  # Start loop from zero index
+  loop_z=$(python -c "print(${orgclarz}-1)")
 
-    # printf "\n loop z: ${loop_z} \n" 
+  firstlblclar=${tifdirregfinal}/lbls_clar_slice_000000.tif
 
-    if [[ ! -f ${firstlblclar} ]]; then
+  printf "\n firstslice: %s \n" "${firstslice}"
+  printf "\n firstslice x: %s \n" "${firstslicex}"
+  printf "\n firstslice y: %s \n" "${firstslicey}"
 
-    	printf "\n Resampling tiff slices to original space \n"
+  # printf "\n loop z: ${loop_z} \n"
 
-		for i in $(seq 0 ${loop_z}); 
-			do 
-				i=$(printf %06d $i) ; 
-				ResampleImage 2 ${tifdirreg}/lbls_slice_${i}.tif ${tifdirregfinal}/lbls_clar_slice_${i}.tif ${firstslicex}x${firstslicey} 1 1 3 ; 
-		done
+  if [[ ! -f "${firstlblclar}" ]]; then
 
-	fi
+    printf "\n Resampling tiff slices to original space \n"
 
+    for i in $(seq 0 "${loop_z}"); do
+      i=$(printf %06d "$i")
+      ResampleImage 2 "${tifdirreg}"/lbls_slice_"${i}".tif "${tifdirregfinal}"/lbls_clar_slice_"${i}".tif "${firstslicex}"x"${firstslicey}" 1 1 3
+    done
 
+  fi
 
-    # warp nifti to org space
-    orgspacing=`PrintHeader ${inclar} 1`
+  # warp nifti to org space
+  orgspacing=$(PrintHeader "${inclar}" 1)
 
-    ifdsntexistrun ${wrplblsorg} "Resampling labels to original space" \
-    ResampleImage 3 ${wrplbls} ${wrplblsorg} ${orgspacing} 0 1
+  ifdsntexistrun "${wrplblsorg}" "Resampling labels to original space" \
+    ResampleImage 3 "${wrplbls}" "${wrplblsorg}" "${orgspacing}" 0 1
 
-    ifdsntexistrun ${orgortlbls} "Orienting Allen labels to original space" \
-    SetDirectionByMatrix ${wrplblsorg} ${orgortlbls} ${ortmatrix}
+  ifdsntexistrun "${orgortlbls}" "Orienting Allen labels to original space" \
+    SetDirectionByMatrix "${wrplblsorg}" "${orgortlbls}" "${ortmatrix}"
 
-    # extract region
-    lblsdim=`PrintHeader ${orgortlbls} 2`
-    lx=${lblsdim%%x*} ;
-    lyz=${lblsdim#*x} ; ly=${lyz%x*} ;
-    lz=${lblsdim##*x} ;
+  # extract region
+  lblsdim=$(PrintHeader "${orgortlbls}" 2)
+  lx=${lblsdim%%x*}
+  lyz=${lblsdim#*x}
+  ly=${lyz%x*}
+  lz=${lblsdim##*x}
 
-    xd=$(($lx-$x))
-    yd=$(($ly-$y))
-    zd=$(($lz-$z))
+  xd=$(($lx - $x))
+  yd=$(($ly - $y))
+  zd=$(($lz - $z))
 
-    xr=$(($xd/2))
-    yr=$(($yd/2))
-    zr=$(($zd/2))
+  xr=$(($xd / 2))
+  yr=$(($yd / 2))
+  zr=$(($zd / 2))
 
-    ifdsntexistrun ${lblsorgnii} "Extracting labels to original size" \
-     c3d ${orgortlbls} -region ${xr}x${yr}x${zr} ${alldim} -o ${lblsorgnii}
+  ifdsntexistrun ${lblsorgnii} "Extracting labels to original size" \
+    c3d ${orgortlbls} -region ${xr}x${yr}x${zr} ${alldim} -o ${lblsorgnii}
 
-    c3d ${inclar} ${lblsorgnii} -copy-transform -o ${lblsorgnii}
+  c3d ${inclar} ${lblsorgnii} -copy-transform -o ${lblsorgnii}
 
-	# set type to int16, to match original labelmap 
-    c3d ${lblsorgnii} -type uint -o ${lblsorgnii}
+  # set type to int16, to match original labelmap
+  c3d ${lblsorgnii} -type uint -o ${lblsorgnii}
 
 }
 
@@ -992,32 +1006,30 @@ function warpallenlbls()
 
 # 4a) Warp input CLARITY to Allen Function
 
-function warpinclarallen()
-{
+function warpinclarallen() {
 
-	# Ort clar
-	inclar=$1
-	ortclartag=$2
-	ortclarint=$3
-	ortclartype=$4
-	orthresclar=$5
+  # Ort clar
+  inclar=$1
+  ortclartag=$2
+  ortclarint=$3
+  ortclartype=$4
+  orthresclar=$5
 
-	# Reg to allen
-	allenhres=$6
-	initform=$7
-	antsaff=$8
-	antsinvwarp=$9
+  # Reg to allen
+  allenhres=$6
+  initform=$7
+  antsaff=$8
+  antsinvwarp=$9
 
-	regorgclar=${10}
+  regorgclar=${10}
 
-	# Orient channel to std
-	orientimg ${inclar} ${ortclartag} ${ortclarint} ${ortclartype} ${orthresclar}
+  # Orient channel to std
+  orientimg "${inclar}" "${ortclartag}" "${ortclarint}" "${ortclartype}" "${orthresclar}"
 
-	# Apply warps
-	ifdsntexistrun ${regorgclar} "Applying ants deformation to input CLARITY" \
-	antsApplyTransforms -r ${allenhres} -i ${orthresclar} -n Bspline \
-	-t [ ${initform}, 1 ] [ ${antsaff}, 1 ] ${antsinvwarp} -o ${regorgclar} --float
-
+  # Apply warps
+  ifdsntexistrun "${regorgclar}" "Applying ants deformation to input CLARITY" \
+    antsApplyTransforms -r "${allenhres}" -i "${orthresclar}" -n Bspline \
+    -t [ "${initform}," 1 ] [ "${antsaff}," 1 ] "${antsinvwarp}" -o "${regorgclar}" --float
 
 }
 
@@ -1025,32 +1037,30 @@ function warpinclarallen()
 
 # 4b) Warp down 3x CLARITY (high res) to Allen Function
 
+function warphresclarallen() {
 
-function warphresclarallen()
-{
+  # Ort clar
+  hresclar=$1
+  ortclartag=$2
+  ortclarint=$3
+  ortclartype=$4
+  orthresclar=$5
 
-	# Ort clar
-	hresclar=$1
-	ortclartag=$2
-	ortclarint=$3
-	ortclartype=$4
-	orthresclar=$5
+  # Reg to allen
+  allenhres=$6
+  initform=$7
+  antsaff=$8
+  antsinvwarp=$9
 
-	# Reg to allen
-	allenhres=$6
-	initform=$7
-	antsaff=$8
-	antsinvwarp=$9
-	
-	regorgclar=${10}
+  regorgclar=${10}
 
-	# Orient channel to std
-	orientimg ${hresclar} ${ortclartag} ${ortclarint} ${ortclartype} ${orthresclar}
+  # Orient channel to std
+  orientimg "${hresclar}" "${ortclartag}" "${ortclarint}" "${ortclartype}" "${orthresclar}"
 
-	# Apply warps
-	ifdsntexistrun ${regorgclar} "Applying ants deformation to high-res CLARITY" \
-	antsApplyTransforms -r ${allenhres} -i ${orthresclar} -n Bspline \
-	 -t [ ${initform}, 1 ] [ ${antsaff}, 1 ] ${antsinvwarp} -o ${regorgclar} --float
+  # Apply warps
+  ifdsntexistrun "${regorgclar}" "Applying ants deformation to high-res CLARITY" \
+    antsApplyTransforms -r "${allenhres}" -i "${orthresclar}" -n Bspline \
+    -t [ "${initform}", 1 ] [ "${antsaff}," 1 ] "${antsinvwarp}" -o "${regorgclar}" --float
 
 }
 
@@ -1058,265 +1068,247 @@ function warphresclarallen()
 
 # 5) Create Tiled Mosaic
 
-function createtiledimg()
-{
-    local smclarres=$1
-    local clipped=$2
-    local wrplbls=$3
-    local rgb_lbls=$4
-    local lbl_mask=$5
-    local custom_lut=$6
-    local mosaic=$7
-    local reghemi=$8
+function createtiledimg() {
+  local smclarres=$1
+  local clipped=$2
+  local wrplbls=$3
+  local rgb_lbls=$4
+  local lbl_mask=$5
+  local custom_lut=$6
+  local mosaic=$7
+  local reghemi=$8
 
-    # clip clar intensities
-    ifdsntexistrun ${clipped} "Clipping CLARITY intensities" \
-    c3d ${smclarres} -stretch 2% 98% 0 255 -clip 0 255 -o ${clipped}
+  # clip clar intensities
+  ifdsntexistrun "${clipped}" "Clipping CLARITY intensities" \
+    c3d "${smclarres}" -stretch 2% 98% 0 255 -clip 0 255 -o "${clipped}"
 
-    ifdsntexistrun ${lbl_mask} "Making labels mask" \
-    ThresholdImage 3 ${wrplbls} ${lbl_mask} 1 inf 1 0
+  ifdsntexistrun "${lbl_mask}" "Making labels mask" \
+    ThresholdImage 3 "${wrplbls}" "${lbl_mask}" 1 inf 1 0
 
-    # create rgb labels
-    ifdsntexistrun ${rgb_lbls} "Creating RGB labels" \
-    ConvertScalarImageToRGB 3 ${wrplbls} ${rgb_lbls} ${lbl_mask} custom ${custom_lut}
+  # create rgb labels
+  ifdsntexistrun "${rgb_lbls}" "Creating RGB labels" \
+    ConvertScalarImageToRGB 3 "${wrplbls}" "${rgb_lbls}" "${lbl_mask}" custom "${custom_lut}"
 
-    # create image
-    if [[ ${reghemi} == "combined" ]]; then
-        png_dir=2
-        flip='0x1'
-    else
-        png_dir=0
-        flip='0x0'
-    fi
+  # create image
+  if [[ "${reghemi}" == "combined" ]]; then
+    png_dir=2
+    flip='0x1'
+  else
+    png_dir=0
+    flip='0x0'
+  fi
 
-    ifdsntexistrun ${mosaic} "Creating tiled mosaic image" \
-#    CreateTiledMosaic -i ${clipped} -r ${rgb_lbls} -a 0.3 -o ${mosaic} -t -1x7 -f '0x1' -s [10,350,1000] -x ${lbl_mask}
-    CreateTiledMosaic -i ${clipped} -r ${rgb_lbls} -a 0.3 -o ${mosaic} -f ${flip} -x ${lbl_mask} -d ${png_dir}
-
+  ifdsntexistrun "${mosaic}" "Creating tiled mosaic image"
+  #    CreateTiledMosaic -i ${clipped} -r ${rgb_lbls} -a 0.3 -o ${mosaic} -t -1x7 -f '0x1' -s [10,350,1000] -x ${lbl_mask}
+  CreateTiledMosaic -i "${clipped}" -r "${rgb_lbls}" -a 0.3 -o "${mosaic}" -f "${flip}" -x "${lbl_mask}" -d "${png_dir}"
 
 }
 
 #---------------------------
 #---------------------------
-
-
 
 # Build main function
 
-function main()
-{
+function main() {
 
-# 1) Process clarity
+  # 1) Process clarity
 
-	# resample to 0.05mm voxel
-	resclar=${regdir}/clar_res0.05.nii.gz
-	resampleclar ${inclar} 0.05 0 4 ${resclar}
+  # resample to 0.05mm voxel
+  resclar="${regdir}"/clar_res0.05.nii.gz
+  resampleclar "${inclar}" 0.05 0 4 "${resclar}"
 
-    # get brain mask (thresh & largest comp)
-    mask=${regdir}/brain_mask.nii.gz
-    brain=${regdir}/brain.nii.gz
-    sharp=${regdir}/clar_res0.05_sharp.nii.gz
-    median=${regdir}/clar_res0.05_median.nii.gz
-    biasin=${regdir}/clar_res0.05_median_bias.nii.gz
-    otsumaskthr=${regdir}/clar_res0.05_median_bias_otsu_mask_prethr.nii.gz
-    otsumask=${regdir}/clar_res0.05_median_bias_otsu_mask.nii.gz
-    otsucp=${regdir}/clar_res0.05_median_bias_otsu_precp.nii.gz
-    otsu=${regdir}/clar_res0.05_median_bias_otsu.nii.gz
+  # get brain mask (thresh & largest comp)
+  mask=${regdir}/brain_mask.nii.gz
+  brain=${regdir}/brain.nii.gz
+  sharp=${regdir}/clar_res0.05_sharp.nii.gz
+  median=${regdir}/clar_res0.05_median.nii.gz
+  biasin=${regdir}/clar_res0.05_median_bias.nii.gz
+  otsumaskthr=${regdir}/clar_res0.05_median_bias_otsu_mask_prethr.nii.gz
+  otsumask=${regdir}/clar_res0.05_median_bias_otsu_mask.nii.gz
+  otsucp=${regdir}/clar_res0.05_median_bias_otsu_precp.nii.gz
+  otsu=${regdir}/clar_res0.05_median_bias_otsu.nii.gz
 
-    if [[ ! -f "${otsu}" ]]; then
-        getbrainmask ${resclar} ${sharp} ${median} ${brain} ${mask} ${biasin} ${otsumaskthr} ${otsumask} ${otsucp} ${otsu}
-    fi
+  if [[ ! -f "${otsu}" ]]; then
+    getbrainmask "${resclar}" "${sharp}" "${median}" "${brain}" "${mask}" "${biasin}" "${otsumaskthr}" "${otsumask}" "${otsucp}" "${otsu}"
+  fi
 
-	# Mask
-	masclar=${regdir}/clar_res0.05_masked.nii.gz
-	maskimage ${resclar} ${otsumask} ${masclar}
-#	maskimage ${resclar} ${mask} ${masclar}
+  # Mask
+  masclar=${regdir}/clar_res0.05_masked.nii.gz
+  maskimage "${resclar}" "${otsumask}" "${masclar}"
+  #	maskimage ${resclar} ${mask} ${masclar}
 
-    if [[ "${prebias}" == 1 ]]; then
-        biasclar=${masclar}
-    else
-        # N4 bias correct
-        biasclar=${regdir}/clar_res0.05_bias.nii.gz
-        biasfieldcorr ${masclar} ${biasclar} ${otsumask}
+  if [[ "${prebias}" == 1 ]]; then
+    biasclar=${masclar}
+  else
+    # N4 bias correct
+    biasclar=${regdir}/clar_res0.05_bias.nii.gz
+    biasfieldcorr "${masclar}" "${biasclar}" "${otsumask}"
 
-    fi
+  fi
 
-    # pad image
-    padclar=${regdir}/clar_res0.05_pad.nii.gz
-    padimage ${biasclar} ${padclar}
+  # pad image
+  padclar=${regdir}/clar_res0.05_pad.nii.gz
+  padimage "${biasclar}" "${padclar}"
 
-	# Orient
-	ortclar=${regdir}/clar_res0.05_ort.nii.gz
-	orientimg ${padclar} "${ort}" Cubic float ${ortclar}
+  # Orient
+  ortclar=${regdir}/clar_res0.05_ort.nii.gz
+  orientimg "${padclar}" "${ort}" Cubic float "${ortclar}"
 
-	# Smooth, convert datatype to ushort
-	smclar=${regdir}/clar_res0.05_sm.nii.gz
-	smoothimg ${ortclar} 0.25 ${smclar}
-	# c3d ${smclar} -type ushort -o ${smclar}
+  # Smooth, convert datatype to ushort
+  smclar=${regdir}/clar_res0.05_sm.nii.gz
+  smoothimg "${ortclar}" 0.25 "${smclar}"
+  # c3d ${smclar} -type ushort -o ${smclar}
 
-	# make clarity copy, convert datatype to ushort
-	clarlnk=${regdir}/clar.nii.gz
-	if [[ ! -f "${clarlnk}" ]]; then cp ${smclar} ${clarlnk} ; fi
+  # make clarity copy, convert datatype to ushort
+  clarlnk=${regdir}/clar.nii.gz
+  if [[ ! -f "${clarlnk}" ]]; then cp "${smclar}" "${clarlnk}"; fi
 
+  #---------------------------
 
-	#---------------------------
+  # 2a) initialize registration
 
+  # Allen atlas template
+  if [[ -z "${atlas}" ]] || [[ "${atlas}" == "None" ]]; then
+    if [[ "${bulb}" == 0 ]]; then
+      allenref=${atlasdir}/ara/template/average_template_25um_OBmasked${side}.nii.gz
 
-# 2a) initialize registration
-
-	# Allen atlas template
-    if [[ -z "${atlas}" ]] || [[ "${atlas}" == "None" ]]; then
-        if [[ "${bulb}" == 0 ]]; then
-            allenref=${atlasdir}/ara/template/average_template_25um_OBmasked${side}.nii.gz
-
-        elif [[ "${bulb}" == 1 ]]; then
-            allenref=${atlasdir}/ara/template/average_template_25um${side}.nii.gz
-
-        fi
-    else
-        # custom input Allen atlas
-        allenref=${atlas}
-
-        custom_lbls=${regdir}/${lblsname}.nii.gz
-        c3d ${allenref} ${lbls} -reslice-identity -o ${custom_lbls}
-        lbls=${custom_lbls}
+    elif [[ "${bulb}" == 1 ]]; then
+      allenref=${atlasdir}/ara/template/average_template_25um${side}.nii.gz
 
     fi
+  else
+    # custom input Allen atlas
+    allenref=${atlas}
 
-	initform=${regdir}/init_tform.mat
+    custom_lbls=${regdir}/${lblsname}.nii.gz
+    c3d "${allenref}" "${lbls}" -reslice-identity -o "${custom_lbls}"
+    lbls=${custom_lbls}
 
-	# Init parms
+  fi
 
-	deg=1 # search increment in degrees
-	radfrac=1 # arc around principal axis
-	useprincax=0 # rotation searched around principal axis
-	localiter=500 # num of iteration for optimization at search point
+  initform=${regdir}/init_tform.mat
 
-	# Out Allen
-	initallen=${regdir}/init_allen.nii.gz
+  # Init parms
 
+  deg=1         # search increment in degrees
+  radfrac=1     # arc around principal axis
+  useprincax=0  # rotation searched around principal axis
+  localiter=500 # num of iteration for optimization at search point
 
-	initclarallenreg ${clarlnk} ${allenref} ${initform} ${deg} ${radfrac} ${useprincax} ${localiter} ${initallen}
+  # Out Allen
+  initallen=${regdir}/init_allen.nii.gz
 
+  initclarallenreg "${clarlnk}" "${allenref}" "${initform}" "${deg}" "${radfrac}" "${useprincax}" "${localiter}" "${initallen}"
 
-	#---------------------------
+  #---------------------------
 
+  # 2b) Register to Allen atlas
 
-# 2b) Register to Allen atlas
+  # Parameters:
 
-	# Parameters: 
+  # transform
+  trans=b #Bspline Syn
+  # spline distance 26
+  spldist=26
+  # cross correlation radius
+  rad=2
+  # precision
+  prec=d # double precision (otherwise ITK error in some cases!)
+  # get num of threads
+  thrds=$(nproc)
 
-	# transform
-	trans=b #Bspline Syn
-	# spline distance 26 
-	spldist=26
-	# cross correlation radius
-	rad=2
-	# precision 
-	prec=d # double precision (otherwise ITK error in some cases!)
-	# get num of threads 
-	thrds=`nproc`
+  # Out Allen
+  antsallen=${regdir}/allen_clar_antsWarped.nii.gz
 
-	# Out Allen
-	antsallen=${regdir}/allen_clar_antsWarped.nii.gz
+  regclarallen "${clarroi}" "${initallen}" "${trans}" "${spldist}" "${rad}" "${prec}" "${thrds}" "${antsallen}"
 
+  #---------------------------
 
-	regclarallen ${clarroi} ${initallen} ${trans} ${spldist} ${rad} ${prec} ${thrds} ${antsallen}
+  # 3) Warp Allen labels to original CLARITY (down sampled 2x)
 
+  # Tforms
+  antswarp=${regdir}/allen_clar_ants1Warp.nii.gz
+  antsaff=${regdir}/allen_clar_ants0GenericAffine.mat
 
-	#---------------------------
+  # Out lbls
+  wrplbls=${regdirfinal}/${lblsname}_clar_downsample.nii.gz
+  ortlbls=${regdir}/${lblsname}_ants_ort.nii.gz
+  swplbls=${regdir}/${lblsname}_ants_swp.nii.gz
+  tiflbls=${regdirfinal}/${lblsname}_clar_vox.tif
+  reslbls=${regdirfinal}/${lblsname}_clar.nii.gz
+  unpadtif=${regdir}/${lblsname}_unpad_clar.tif
+  restif=${regdirfinal}/${lblsname}_clar.tif
 
+  smclarres=${regdirfinal}/clar_downsample_res${vox}um.nii.gz
 
-# 3) Warp Allen labels to original CLARITY (down sampled 2x)
+  wrplblsorg=${regdir}/${lblsname}_ants_org.nii.gz
+  orgortlbls=${regdir}/${lblsname}_ants_org_ort.nii.gz
+  lblsorgnii=${regdirfinal}/${lblsname}_clar_space_downsample.nii.gz
 
-	# Tforms
-	antswarp=${regdir}/allen_clar_ants1Warp.nii.gz
-	antsaff=${regdir}/allen_clar_ants0GenericAffine.mat
+  tiflblszstack=${regdir}/${lblsname}_unpad_clar_zstack.tif
+  tifdirreg=${regdir}/${lblsname}_tiff
+  tifdirregfinal=${regdirfinal}/${lblsname}_tiff_clar
 
-	# Out lbls
-	wrplbls=${regdirfinal}/${lblsname}_clar_downsample.nii.gz
-	ortlbls=${regdir}/${lblsname}_ants_ort.nii.gz
-	swplbls=${regdir}/${lblsname}_ants_swp.nii.gz
-	tiflbls=${regdirfinal}/${lblsname}_clar_vox.tif
-	reslbls=${regdirfinal}/${lblsname}_clar.nii.gz
-	unpadtif=${regdir}/${lblsname}_unpad_clar.tif
-	restif=${regdirfinal}/${lblsname}_clar.tif
+  # orgclar, tiflbls_zstack , tifdir_reg, tifdir_regfinal
 
-	smclarres=${regdirfinal}/clar_downsample_res${vox}um.nii.gz
+  warpallenlbls "${smclar}" "${lbls}" "${antswarp}" "${antsaff}" "${initform}" "${wrplbls}" \
+    "${ortlbls}" "${swplbls}" "${tiflbls}" "${inclar}" "${reslbls}" "${restif}" "${vox}" \
+    "${smclarres}" "${inclar}" "${orgortlbls}" "${lblsorgnii}" "${wrplblsorg}" "${unpadtif}" \
+    "${orgclar}" "${tiflblszstack}" "${tifdirreg}" "${tifdirregfinal}"
 
-    wrplblsorg=${regdir}/${lblsname}_ants_org.nii.gz
-    orgortlbls=${regdir}/${lblsname}_ants_org_ort.nii.gz
-    lblsorgnii=${regdirfinal}/${lblsname}_clar_space_downsample.nii.gz
+  #---------------------------
 
-    tiflblszstack=${regdir}/${lblsname}_unpad_clar_zstack.tif
-    tifdirreg=${regdir}/${lblsname}_tiff
-    tifdirregfinal=${regdirfinal}/${lblsname}_tiff_clar
+  # 4) Warp input CLARITY to Allen
 
-	# orgclar, tiflbls_zstack , tifdir_reg, tifdir_regfinal 
+  # ort hres clar
+  ortinclar="${regdir}"/clar_ort.nii.gz
 
-	warpallenlbls ${smclar} ${lbls} ${antswarp} ${antsaff} ${initform} ${wrplbls} \
-	 ${ortlbls} ${swplbls} ${tiflbls} ${inclar} ${reslbls} ${restif} ${vox} \
-	  ${smclarres} ${inclar} ${orgortlbls} ${lblsorgnii} ${wrplblsorg} ${unpadtif} \
-	  ${orgclar} ${tiflblszstack} ${tifdirreg} ${tifdirregfinal}
+  # hres Allen
+  allenhres="${atlasdir}"/ara/template/average_template_10um.nii.gz
 
+  # ants inv warp
+  antsinvwarp="${regdir}"/allen_clar_ants1InverseWarp.nii.gz
 
-	#---------------------------
+  # out warp hres clar
+  regorgclar="${regdirfinal}"/clar_allen_space.nii.gz
 
+  if [[ "${warphres}" == 1 ]]; then
+    warpinclarallen "${inclar}" "${ort}" Cubic uint "${ortinclar}" "${allenhres}" \
+      "${initform}" "${antsaff}" "${antsinvwarp}" "${regorgclar}"
+  fi
 
-# 4) Warp input CLARITY to Allen
+  #---------------------------
 
+  # 5) Create Tiled Mosaic
 
-	# ort hres clar
-	ortinclar=${regdir}/clar_ort.nii.gz
+  clipped="${regdir}"/clar_downsample_res${vox}um_int_clipped.nii.gz
+  custom_lut="${atlasdir}"/ara/ara_ants_lut.txt
+  rgb_lbls="${regdir}"/"${lblsname}"_clar_downsample_rgb.nii.gz
+  lbl_mask="${regdir}"/"${lblsname}"_clar_downsample_mask.nii.gz
+  mosaic="${regdirfinal}"/allen_labels_to_clar_mosaic.png
 
-	# hres Allen
-	allenhres=${atlasdir}/ara/template/average_template_10um.nii.gz
-
-	# ants inv warp
-	antsinvwarp=${regdir}/allen_clar_ants1InverseWarp.nii.gz
-
-	# out warp hres clar
-    regorgclar=${regdirfinal}/clar_allen_space.nii.gz
-
-    if [[ "${warphres}" == 1 ]]; then
-        warpinclarallen ${inclar} ${ort} Cubic uint ${ortinclar} ${allenhres} \
-         ${initform} ${antsaff} ${antsinvwarp} ${regorgclar}
-    fi
-
-    #---------------------------
-
-
-# 5) Create Tiled Mosaic
-
-    clipped=${regdir}/clar_downsample_res${vox}um_int_clipped.nii.gz
-    custom_lut=${atlasdir}/ara/ara_ants_lut.txt
-    rgb_lbls=${regdir}/${lblsname}_clar_downsample_rgb.nii.gz
-    lbl_mask=${regdir}/${lblsname}_clar_downsample_mask.nii.gz
-    mosaic=${regdirfinal}/allen_labels_to_clar_mosaic.png
-
-    if [[ "${savefig}" == 1 ]]; then
-        createtiledimg ${smclarres} ${clipped} ${wrplbls} ${rgb_lbls} ${lbl_mask} ${custom_lut} ${mosaic} ${hemi}
-    fi
+  if [[ "${savefig}" == 1 ]]; then
+    createtiledimg "${smclarres}" "${clipped}" "${wrplbls}" "${rgb_lbls}" "${lbl_mask}" "${custom_lut}" "${mosaic}" "${hemi}"
+  fi
 
 }
-
 
 #--------------------
 
 # call main function
 main
 
-# get script timing 
+# get script timing
 END=$(date +%s)
-DIFF=$((END-START))
-DIFF=$((DIFF/60))
+DIFF=$((END - START))
+DIFF=$((DIFF / 60))
 
 miracl utils end_state -f "Registration and Allen labels warping" -t "$DIFF minutes"
-
 
 # TODOs
 # TODOlp: add settings file to read for pars
 
 # create output file for successful completion
 command="${vox}\n${ort}"
-echo -e $command > "$work_dir/reg_final/reg_command.log"
+echo -e "${command}" >"${work_dir}/reg_final/reg_command.log"
+

--- a/miracl/reg/miracl_reg_clar-allen_utility.py
+++ b/miracl/reg/miracl_reg_clar-allen_utility.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+import tifffile
+import numpy as np
+from typing import Union
+from os import PathLike
+import argparse
+
+
+def extract_tiff_slices(
+    input_file: Union[str, PathLike],
+    output_dir: Union[str, PathLike],
+    raw_slice_name_template: str,
+) -> None:
+    """
+    Extract slices from a TIFF stack.
+
+    Args:
+        input_file (Union[str, PathLike]): Path to the input TIFF file.
+        output_dir (Union[str, PathLike]): Directory to save extracted slices.
+        raw_slice_name_template (str): Template for naming output files (e.g., "lbls_slice_%06d.tif").
+
+    Raises:
+        FileNotFoundError: If input_file doesn't exist.
+        NotADirectoryError: If output_dir is not a directory.
+    """
+    input_path = Path(input_file)
+    output_path = Path(output_dir)
+
+    if not input_path.is_file():
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+    if not output_path.is_dir():
+        raise NotADirectoryError(f"Output directory is not valid: {output_path}")
+
+    with tifffile.TiffFile(input_path) as tif:
+        stack = tif.asarray()
+
+    for z in range(stack.shape[0]):
+        slice_data = stack[z, :, :].astype(np.uint16)
+        img_filename = output_path / (raw_slice_name_template % z)
+        print(f"Saving img: {img_filename}")
+        tifffile.imwrite(
+            img_filename,
+            slice_data,
+            metadata={
+                "DimensionOrder": "YX",
+                "SizeC": 1,
+                "SizeT": 1,
+                "SizeX": slice_data.shape[1],
+                "SizeY": slice_data.shape[0],
+            },
+        )
+
+
+def main() -> None:
+    # Create an argument parser
+    parser = argparse.ArgumentParser(description="Extract slices from a tif stack.")
+
+    # Add arguments to the parser
+    parser.add_argument(
+        "input_file",
+        type=str,
+        help="Path to the input tif file",
+    )
+    parser.add_argument(
+        "output_dir",
+        type=str,
+        help="Directory to save extracted tiff slices",
+    )
+    parser.add_argument(
+        "raw_slice_name_template",
+        type=str,
+        help="Template for naming extracted tif slices files",
+    )
+
+    # Parse arguments
+    args = parser.parse_args()
+
+    # Call the function with parsed arguments
+    extract_tiff_slices(args.input_file, args.output_dir, args.raw_slice_name_template)
+
+
+# Ensure the script runs only when called directly
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This fixes several major issues in the Clarity Allen registration script:
1. Channel prefix and number are now flags in the Clarity Allen registration method. This is necessary for registrations of scans that used channel prefix and number for conversion (e.g. LaVision). Before this would fail as the registration script had no method to differentiate between e.g. autoflor and signal channels in the RAW tif folder delimited by the channel prefix/number combination.
2. The tif stack extraction uses `tifffile` now instead of `c3d`. The latter was failing with larger tif files (e.g. SMARTSpim vs. LaVision). Debugging/profiling indicated that larger files (SMARTSpim) triggered parallel processing in `c3d` which potentially lead to race conditions that weren't apparent when extracting smaller files (LaVision). The result was that the stack got extracted with the slides being out of order.